### PR TITLE
fix(metrics/repository - controller): Removed method countSubsByPerio…

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionMetricsController.java
@@ -1,7 +1,6 @@
 package com.jame.dev.gymApp.controller.routes.app.admin;
 
 import com.jame.dev.gymApp.metrics.service.in.SubscriptionMetricsService;
-import com.jame.dev.gymApp.model.metrics.PeriodCountDto;
 import com.jame.dev.gymApp.model.metrics.SubsPerMembership;
 import com.jame.dev.gymApp.model.metrics.SubsPerMonthDto;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +32,6 @@ public class SubscriptionMetricsController {
    public ResponseEntity<Map<String, Long>> getTotalBefore(@PathVariable("date") final LocalDate date){
       final long total = service.getSubscriptionsBefore(date);
       return buildResponseMap(total);
-   }
-
-   @GetMapping("/periods")
-   public ResponseEntity<List<PeriodCountDto>> getPerPeriod(){
-      return ResponseEntity.ok(service.getSubscriptionsPerPeriod());
    }
 
    @GetMapping("/memberships")

--- a/src/main/java/com/jame/dev/gymApp/metrics/repo/SubscriptionMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/metrics/repo/SubscriptionMetricsRepository.java
@@ -1,7 +1,6 @@
 package com.jame.dev.gymApp.metrics.repo;
 
 import com.jame.dev.gymApp.entity.SubscriptionEntity;
-import com.jame.dev.gymApp.model.metrics.PeriodCountDto;
 import com.jame.dev.gymApp.model.metrics.SubsPerMembership;
 import com.jame.dev.gymApp.model.metrics.SubsPerMonthDto;
 import com.jame.dev.gymApp.repository.common.MetricsRepository;
@@ -17,29 +16,25 @@ public interface SubscriptionMetricsRepository extends
    long countDistinctByActiveTrueAndFinishedFalse();
 
    @Query("""
-           SELECT COUNT(DISTINCT s) FROM SubscriptionEntity s
-           JOIN s.subscriptionPeriods p
-           WHERE s.active = true AND p.startPeriod < :now
+           SELECT COUNT(s) FROM SubscriptionEntity s
+           WHERE s.active = true
+           AND EXISTS (
+               SELECT 1 FROM s.subscriptionPeriods p
+               WHERE p.startPeriod < :now
+           )
            """)
-   long countByStartDateBefore(@Param("now") final LocalDate now);
+   long countByStartDateBefore(@Param("now") LocalDate now);
 
    @Query("""
-           SELECT p.period, COUNT(DISTINCT s)
-           FROM SubscriptionEntity s
-           JOIN s.subscriptionPeriods p
-           WHERE s.active = true AND s.finished = false
-           GROUP BY p.period
-           """)
-   List<PeriodCountDto> countSubsByPeriod();
-
-   @Query("""
-           SELECT
-               FUNCTION('TO_CHAR', p.startPeriod, 'FMMonth'), COUNT(s)
+           SELECT new com.jame.dev.gymApp.model.metrics.SubsPerMonthDto(
+               CAST(FUNCTION('TO_CHAR', p.startPeriod, 'FMMonth') AS string) AS month,
+               COUNT(s) as total
+           )
            FROM SubscriptionEntity s
            JOIN s.subscriptionPeriods p
            WHERE s.active = true AND s.finished = false
            GROUP BY FUNCTION('TO_CHAR', p.startPeriod, 'FMMonth')
-           ORDER BY FUNCTION('TO_CHAR', p.startPeriod, 'FMMonth')
+           ORDER BY MIN(p.startPeriod)
            """)
    List<SubsPerMonthDto> countSubsByMonth();
 
@@ -49,6 +44,7 @@ public interface SubscriptionMetricsRepository extends
            FROM SubscriptionEntity s
            JOIN s.pricing.memberShipEntity m
            GROUP BY m.membership
+           ORDER BY m.membership ASC
            """)
    List<SubsPerMembership> countSubsByMembership();
 }

--- a/src/main/java/com/jame/dev/gymApp/metrics/service/in/SubscriptionMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/metrics/service/in/SubscriptionMetricsService.java
@@ -1,6 +1,5 @@
 package com.jame.dev.gymApp.metrics.service.in;
 
-import com.jame.dev.gymApp.model.metrics.PeriodCountDto;
 import com.jame.dev.gymApp.model.metrics.SubsPerMembership;
 import com.jame.dev.gymApp.model.metrics.SubsPerMonthDto;
 import lombok.NonNull;
@@ -12,8 +11,6 @@ public interface SubscriptionMetricsService {
    long getTotalSubscriptions();
 
    long getSubscriptionsBefore(@NonNull final LocalDate date);
-
-   List<PeriodCountDto> getSubscriptionsPerPeriod();
 
    List<SubsPerMonthDto> getSubscriptionsPerMonth();
 

--- a/src/main/java/com/jame/dev/gymApp/metrics/service/out/SubscriptionMetricsServiceImp.java
+++ b/src/main/java/com/jame/dev/gymApp/metrics/service/out/SubscriptionMetricsServiceImp.java
@@ -2,7 +2,6 @@ package com.jame.dev.gymApp.metrics.service.out;
 
 import com.jame.dev.gymApp.metrics.repo.SubscriptionMetricsRepository;
 import com.jame.dev.gymApp.metrics.service.in.SubscriptionMetricsService;
-import com.jame.dev.gymApp.model.metrics.PeriodCountDto;
 import com.jame.dev.gymApp.model.metrics.SubsPerMembership;
 import com.jame.dev.gymApp.model.metrics.SubsPerMonthDto;
 import lombok.NonNull;
@@ -27,10 +26,6 @@ public class SubscriptionMetricsServiceImp implements SubscriptionMetricsService
       return repo.countByStartDateBefore(date);
    }
 
-   @Override
-   public List<PeriodCountDto> getSubscriptionsPerPeriod() {
-      return returnList(repo.countSubsByPeriod());
-   }
 
    @Override
    public List<SubsPerMonthDto> getSubscriptionsPerMonth() {

--- a/src/main/java/com/jame/dev/gymApp/model/metrics/SubsPerMonthDto.java
+++ b/src/main/java/com/jame/dev/gymApp/model/metrics/SubsPerMonthDto.java
@@ -4,6 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record SubsPerMonthDto(
         @JsonProperty("month") String month,
-        @JsonProperty("total") long total
+        @JsonProperty("total") Long total
 ) {
 }

--- a/src/test/java/com/jame/dev/gymApp/metrics/service/SubscriptionMetricsServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/metrics/service/SubscriptionMetricsServiceTest.java
@@ -3,11 +3,9 @@ package com.jame.dev.gymApp.metrics.service;
 
 import com.jame.dev.gymApp.metrics.repo.SubscriptionMetricsRepository;
 import com.jame.dev.gymApp.metrics.service.out.SubscriptionMetricsServiceImp;
-import com.jame.dev.gymApp.model.metrics.PeriodCountDto;
 import com.jame.dev.gymApp.model.metrics.SubsPerMembership;
 import com.jame.dev.gymApp.model.metrics.SubsPerMonthDto;
 import com.jame.dev.gymApp.shared.enums.Membership;
-import com.jame.dev.gymApp.shared.enums.Period;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,24 +64,6 @@ public class SubscriptionMetricsServiceTest {
 
       assertNotNull(dateValue, "Date should not be null.");
       assertTrue(count >= 0, "Should return 0 or any long value greater then 0.");
-   }
-   @Test
-   @DisplayName("Should return a list of subs by period")
-   void subsByPeriod() {
-      final List<PeriodCountDto> periodCountList = List.of(
-                      new PeriodCountDto(Period.BIWEEKLY, 4L),
-                      new PeriodCountDto(Period.MONTHLY, 8L),
-                      new PeriodCountDto(Period.QUARTERLY, 10L),
-                      new PeriodCountDto(Period.ANNUAL, 2L));
-      when(repo.countSubsByPeriod())
-              .thenReturn(periodCountList);
-
-      final List<PeriodCountDto> periodCountDtos = service.getSubscriptionsPerPeriod();
-
-      verify(repo, times(1)).countSubsByPeriod();
-      verifyNoMoreInteractions(repo);
-
-      assertNotNull(periodCountDtos, "List should not be null.");
    }
 
    @Test


### PR DESCRIPTION
Changes: 
1. SubscriptionsMetricsController: Removed end-point /periods
- Removed end-point because it was a design miss, the responses of it and /memberships were the same.
2. SubscriptionMetricsrepository: Optimize the JPQL query to get the count of subscriptions before a given date.
3. Also, fixed the query for the method countSubsByMonth, it was giving a contructor Exception, so, absolute contructor declaration was implemented on the query and apply a CAST to his  arguments to ovoid the same exception on building time.
4. Implemented ORDER BY on countSubsByMonth.
5. Removed all usages of countSubsByPeriod.