### PR TITLE
Recovery Oauth 

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/aspects/annotations/VerifyOauthUser.java
+++ b/src/main/java/com/jame/dev/gymApp/aspects/annotations/VerifyOauthUser.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.aspects.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VerifyOauthUser {
+}

--- a/src/main/java/com/jame/dev/gymApp/aspects/imp/PublishVerifyOAuthUser.java
+++ b/src/main/java/com/jame/dev/gymApp/aspects/imp/PublishVerifyOAuthUser.java
@@ -1,0 +1,25 @@
+package com.jame.dev.gymApp.aspects.imp;
+
+
+import com.jame.dev.gymApp.oauth2.model.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class PublishVerifyOAuthUser {
+   private final ApplicationEventPublisher applicationEventPublisher;
+
+   @AfterReturning(
+           pointcut = "@annotation(com.jame.dev.gymApp.aspects.annotations.VerifyOauthUser)",
+           returning = "result")
+   public void publishVerification(final Object result) {
+      if (result instanceof CustomOAuth2User user) {
+         applicationEventPublisher.publishEvent(user.getUser());
+      }
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/auth/RecoveryAccountController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/auth/RecoveryAccountController.java
@@ -41,16 +41,4 @@ public class RecoveryAccountController {
       return ResponseEntity.ok().build();
    }
 
-   @PostMapping("/activate-customer")
-   public ResponseEntity<Void> reActivateCustomerAccount(
-           @RequestBody
-           @Valid
-           @NotNullObject final RecoveryAccountDto recoveryAccountDto
-   ) {
-      accountRecoveryService.reactivateCustomerAccount(
-              recoveryAccountDto.email(),
-              recoveryAccountDto.token()
-      );
-      return ResponseEntity.ok().build();
-   }
 }

--- a/src/main/java/com/jame/dev/gymApp/mapper/RoleMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/mapper/RoleMapper.java
@@ -44,6 +44,12 @@ public interface RoleMapper {
               .collect(Collectors.toSet());
    }
 
+   default Set<Role> toRoleSet(Set<RoleEntity> roles) {
+      return roles.stream()
+              .map(RoleEntity::getRole)
+              .collect(Collectors.toSet());
+   }
+
    default RoleEntity toEntity(Role role, RoleRepository roleRepository){
       if(role == null) return null;
       return roleRepository.findByRole(role)

--- a/src/main/java/com/jame/dev/gymApp/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/jame/dev/gymApp/oauth2/service/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.jame.dev.gymApp.oauth2.service;
 
+import com.jame.dev.gymApp.aspects.annotations.VerifyOauthUser;
 import com.jame.dev.gymApp.mapper.RoleMapper;
 import com.jame.dev.gymApp.model.dto.in.UserDtoInput;
 import com.jame.dev.gymApp.model.dto.out.UserDtoOutput;
@@ -21,7 +22,6 @@ import org.springframework.stereotype.Service;
 import java.util.Collection;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -32,6 +32,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
    private final RoleMapper roleMapper;
 
    @Override
+   @VerifyOauthUser
    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
       final OAuth2User oAuth2User = super.loadUser(userRequest);
       final AuthenticatedUser authenticatedUser = registerUser(oAuth2User);
@@ -48,12 +49,9 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                       u.getId(),
                       u.getName(),
                       u.getEmail(),
-                      u.getRoles()
-                              .stream()
-                              .map(roleMapper::toDto)
-                              .collect(Collectors.toSet())
+                      roleMapper.toRoleSet(u.getRoles())
               ))
-              .orElseGet(() -> registerUser(oAuth2User, email));
+              .orElseGet(() -> saveUser(oAuth2User, email));
       return AuthenticatedUser.builder()
               .id(user.id())
               .name(user.name())
@@ -62,7 +60,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
               .build();
    }
 
-   private @NonNull UserDtoOutput registerUser(final OAuth2User oAuth2User, final String email) {
+   private @NonNull UserDtoOutput saveUser(final OAuth2User oAuth2User, final String email) {
       final UserDtoInput userDtoInput = UserDtoInput.builder()
               .name(oAuth2User.getAttribute("name"))
               .email(email)

--- a/src/main/java/com/jame/dev/gymApp/observers/VerificationOauth2ListenerSaver.java
+++ b/src/main/java/com/jame/dev/gymApp/observers/VerificationOauth2ListenerSaver.java
@@ -1,0 +1,33 @@
+package com.jame.dev.gymApp.observers;
+
+import com.jame.dev.gymApp.entity.VerificationEntity;
+import com.jame.dev.gymApp.oauth2.model.AuthenticatedUser;
+import com.jame.dev.gymApp.service.in.TokenGeneratorService;
+import com.jame.dev.gymApp.service.in.VerificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VerificationOauth2ListenerSaver {
+
+   private final VerificationService verificationService;
+   private final TokenGeneratorService tokenGeneratorService;
+
+   @Async
+   @EventListener
+   public void saveOauthUser(final AuthenticatedUser user) {
+      final boolean exists = verificationService.isVerified(user.email());
+      if (exists) return;
+
+      log.info("Verified Oauth2 User");
+      final String token = tokenGeneratorService.generateToken();
+      final VerificationEntity ignored = verificationService
+              .save(user.id(), token);
+      verificationService.verify(user.email(), token);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/repository/CustomerRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/repository/CustomerRepository.java
@@ -21,4 +21,11 @@ public interface CustomerRepository extends CustomJpaRepository<CustomerEntity, 
    Optional<CustomerEntity> findDeactivatedByUserId(@Param("userId") final long userId);
 
    boolean existsByIdAndUser_EmailAndActiveTrue(long id, String email);
+
+   @Query(nativeQuery = true, value = """
+           SELECT EXISTS(
+                    SELECT 1 FROM customers c
+                    WHERE c.user_id = :userId)
+           """)
+   boolean existsDeactivatedByUserId(@Param("userId") final long userId);
 }

--- a/src/main/java/com/jame/dev/gymApp/service/in/AccountRecoveryService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/in/AccountRecoveryService.java
@@ -2,6 +2,6 @@ package com.jame.dev.gymApp.service.in;
 
 public interface AccountRecoveryService {
    void reActivateUserAccount(final String userEmail, final String token);
-   void reactivateCustomerAccount(final String userEmail, final String token);
+   //void reactivateCustomerAccount(final String userEmail, final String token);
    boolean accountExists(final String userEmail);
 }

--- a/src/main/java/com/jame/dev/gymApp/service/out/AccountRecoveryServiceImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/AccountRecoveryServiceImplementation.java
@@ -1,6 +1,8 @@
 package com.jame.dev.gymApp.service.out;
 
+import com.jame.dev.gymApp.entity.UserEntity;
 import com.jame.dev.gymApp.entity.VerificationEntity;
+import com.jame.dev.gymApp.exception.UserEntityNotFoundException;
 import com.jame.dev.gymApp.exception.VerificationAttemptFailedException;
 import com.jame.dev.gymApp.exception.VerificationNotFoundException;
 import com.jame.dev.gymApp.mapper.RoleMapper;
@@ -45,26 +47,28 @@ public class AccountRecoveryServiceImplementation implements AccountRecoveryServ
    @Transactional
    public void reActivateUserAccount(String userEmail, String token) {
       final VerificationEntity VE = getVerificationEntity(userEmail, token);
-      userRepository.findByEmail(userEmail)
-              .ifPresent(u -> {
-                 u.setActive(true);
-                 u.setUpdatedAt(Instant.now());
-                 u.setRoles(roleMapper.toEntitySet(Set.of(Role.USER), roleRepository));
-                 VE.setUser(u);
-              });
-   }
+      final UserEntity user = userRepository.findByEmail(userEmail)
+              .orElseThrow(() -> new UserEntityNotFoundException("User not found."));
 
-   @Override
-   @Transactional
-   public void reactivateCustomerAccount(String userEmail, String token) {
-      final VerificationEntity VE = getVerificationEntity(userEmail, token);
+      if (!user.isActive()) {
+         user.setActive(true);
+         user.setUpdatedAt(Instant.now());
+         user.setRoles(roleMapper.toEntitySet(Set.of(Role.USER), roleRepository));
+      }
 
-      customerRepository.findDeactivatedByUser_email(userEmail)
-              .ifPresent(CE -> {
-                 CE.setActive(true);
-                 CE.setUpdatedAt(Instant.now());
-                 VE.setUser(CE.getUser());
-              });
+      final long userId = user.getId();
+
+      if(customerRepository.existsDeactivatedByUserId(userId)) {
+         customerRepository.findDeactivatedByUserId(userId)
+                 .ifPresent(c -> {
+                    if (!c.isActive()) {
+                       c.setActive(true);
+                       c.setUpdatedAt(Instant.now());
+                       c.setUser(user);
+                    }
+                 });
+      }
+      VE.setUser(user);
    }
 
    @Override

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/auth/recovery/RecoveryAccountControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/auth/recovery/RecoveryAccountControllerTest.java
@@ -67,7 +67,7 @@ public class RecoveryAccountControllerTest {
    @Test
    @DisplayName("POST[202] Created: Should publish the event")
    void publishEvent() throws Exception {
-      mockMvc.perform(post(URI + '/' + "recover")
+      mockMvc.perform(post(URI + "/recover")
                       .accept(MediaType.APPLICATION_JSON)
                       .contentType(MediaType.APPLICATION_JSON)
                       .content("""
@@ -102,27 +102,6 @@ public class RecoveryAccountControllerTest {
       verifyNoMoreInteractions(accountRecoveryService);
    }
 
-   @Test
-   @DisplayName("POST[200] Ok: Reactivate Customer's account")
-   void reactivateCustomersAccount() throws Exception {
-      willDoNothing().given(accountRecoveryService).reactivateCustomerAccount(anyString(), anyString());
-
-      mockMvc.perform(post(URI + "/activate-customer")
-                      .accept(MediaType.APPLICATION_JSON)
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .content("""
-                              {
-                                 "email": "email@mail.com",
-                                 "token": "token"
-                              }
-                              """)
-              )
-              .andExpect(status().isOk())
-              .andExpect(jsonPath("$.*").doesNotExist());
-      then(accountRecoveryService).should(times(1)).reactivateCustomerAccount(anyString(), anyString());
-      verifyNoMoreInteractions(accountRecoveryService);
-   }
-
    @ParameterizedTest
    @CsvSource(
            useHeadersInDisplayName = true,
@@ -131,7 +110,7 @@ public class RecoveryAccountControllerTest {
            emptyValue = "EMPTY")
    @DisplayName("POST[400] Bad Request due to constraint validations.")
    void endpointForReActivateThrows(String email, String codeError) throws Exception {
-      mockMvc.perform(post(URI + '/' + "re-activate")
+      mockMvc.perform(post(URI + "/activate")
                       .accept(MediaType.APPLICATION_JSON)
                       .contentType(MediaType.APPLICATION_JSON)
                       .content("""

--- a/src/test/java/com/jame/dev/gymApp/service/AccountRecoveryServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/AccountRecoveryServiceTest.java
@@ -51,10 +51,11 @@ public class AccountRecoveryServiceTest {
    AccountRecoveryServiceImplementation accountRecoveryService;
 
    @Test
-   @DisplayName("Should reactivate the account.")
-   void reactivateUserAccount() {
+   @DisplayName("Should reactivate the account of customer and user type.")
+   void reactivateBothAccounts() {
       VerificationEntity verificationEntity = mock(VerificationEntity.class);
       UserEntity userEntity = mock(UserEntity.class);
+      CustomerEntity customerEntity = mock(CustomerEntity.class);
       RoleEntity roleEntity = mock(RoleEntity.class);
 
       given(verificationRepository.findDeactivatedByUser_Email(anyString()))
@@ -64,6 +65,9 @@ public class AccountRecoveryServiceTest {
               .willReturn(Optional.of(userEntity));
       given(roleMapper.toEntitySet(any(), any()))
               .willReturn(Set.of(roleEntity));
+      given(customerRepository.existsDeactivatedByUserId(anyLong())).willReturn(true);
+      given(customerRepository.findDeactivatedByUserId(anyLong()))
+              .willReturn(Optional.of(customerEntity));
       assertDoesNotThrow(
               () -> accountRecoveryService.reActivateUserAccount("any@mail.com", "ABC123")
       );
@@ -72,12 +76,14 @@ public class AccountRecoveryServiceTest {
       then(passwordEncoder).should(times(1)).matches(anyString(), any());
       then(userRepository).should(times(1)).findByEmail(anyString());
       then(roleMapper).should(times(1)).toEntitySet(any(), any());
-      verifyNoMoreInteractions(verificationRepository, passwordEncoder, userRepository, roleMapper);
+      then(customerRepository).should(times(1)).existsDeactivatedByUserId(anyLong());
+      then(customerRepository).should(times(1)).findDeactivatedByUserId(anyLong());
+      verifyNoMoreInteractions(verificationRepository, passwordEncoder, userRepository, roleMapper, customerRepository);
    }
 
    @Test
-   @DisplayName("Should reactivate the customer's account.")
-   void reactivateCustomerAccount() {
+   @DisplayName("Should reactivate only the user account.")
+   void reactivateUserAccount() {
       VerificationEntity verificationEntity = mock(VerificationEntity.class);
       UserEntity user = mock(UserEntity.class);
 
@@ -86,19 +92,50 @@ public class AccountRecoveryServiceTest {
       given(verificationRepository.findDeactivatedByUser_Email(anyString()))
               .willReturn(Optional.of(verificationEntity));
       given(passwordEncoder.matches(anyString(), any())).willReturn(true);
-      given(customerRepository.findDeactivatedByUser_email(anyString()))
-              .willReturn(Optional.of(new CustomerEntity()));
+      given(userRepository.findByEmail(anyString()))
+              .willReturn(Optional.of(user));
+      given(customerRepository.existsDeactivatedByUserId(anyLong())).willReturn(false);
 
       assertDoesNotThrow(
-              () -> accountRecoveryService.reactivateCustomerAccount(email, "ABC123")
+              () -> accountRecoveryService.reActivateUserAccount(email, "ABC123")
       );
 
       then(verificationRepository).should(times(1)).findDeactivatedByUser_Email(anyString());
       then(passwordEncoder).should(times(1)).matches(anyString(), any());
-      then(customerRepository).should(times(1)).findDeactivatedByUser_email(anyString());
-      verifyNoMoreInteractions(verificationRepository, passwordEncoder);
+      then(userRepository).should(times(1)).findByEmail(anyString());
+      then(customerRepository).should(times(1)).existsDeactivatedByUserId(anyLong());
+      verifyNoMoreInteractions(verificationRepository, passwordEncoder, userRepository, customerRepository);
    }
 
+   @Test
+   @DisplayName("Should reactivate only the customer account.")
+   void reactivateCustomerAccount() {
+      VerificationEntity verificationEntity = mock(VerificationEntity.class);
+      UserEntity user = mock(UserEntity.class);
+      CustomerEntity customer = mock(CustomerEntity.class);
+
+      given(verificationRepository.findDeactivatedByUser_Email(anyString()))
+              .willReturn(Optional.of(verificationEntity));
+      given(passwordEncoder.matches(anyString(), any()))
+              .willReturn(true);
+      given(userRepository.findByEmail(anyString()))
+              .willReturn(Optional.of(user));
+      given(user.isActive()).willReturn(true);
+      given(customerRepository.existsDeactivatedByUserId(anyLong()))
+              .willReturn(true);
+      given(customerRepository.findDeactivatedByUserId(anyLong()))
+              .willReturn(Optional.of(customer));
+
+      assertDoesNotThrow(() -> accountRecoveryService.reActivateUserAccount("any@mail.com", "TOKEN"));
+
+      then(verificationRepository).should(times(1)).findDeactivatedByUser_Email(anyString());
+      then(passwordEncoder).should(times(1)).matches(anyString(), any());
+      then(userRepository).should(times(1)).findByEmail(anyString());
+      then(customerRepository).should(times(1)).existsDeactivatedByUserId(anyLong());
+      then(customerRepository).should(times(1)).findDeactivatedByUserId(anyLong());
+
+      verifyNoMoreInteractions(userRepository, customerRepository);
+   }
 
    @Test
    @DisplayName("Should validate if the account exists.")


### PR DESCRIPTION
### Main changes

- > Now at the time while registering a Oauth2 account, this one triggers an event when it's done, and this ensures to save a record on the 'tokens' table (maybe would be good change the table name to 'verifications') to have a way to recover the account when the user request it.
- > Resource /accounts/activate now is only one service for both ways **recover a Customer** and **recover a user** accounts, this fixes the restriction of: **If there's no user, there should've a customer.** because this is a relation of one way from user to customer.