### PR TITLE
Rate Limiter

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/auth/filters/CustomAuthorizationFilter.java
+++ b/src/main/java/com/jame/dev/gymApp/auth/filters/CustomAuthorizationFilter.java
@@ -3,7 +3,10 @@ package com.jame.dev.gymApp.auth.filters;
 import com.jame.dev.gymApp.auth.helpers.CustomAuthorizationFilterHelper;
 import com.jame.dev.gymApp.cache.service.BlacklistService;
 import com.jame.dev.gymApp.exception.AccessExpiredException;
+import com.jame.dev.gymApp.exception.AuthenticationNullException;
 import com.jame.dev.gymApp.exception.TokenAlreadyBlacklistedException;
+import com.jame.dev.gymApp.service.in.RateLimiterService;
+import com.jame.dev.gymApp.service.in.TryCatchBlockExecutorService;
 import com.jame.dev.gymApp.shared.enums.CookieNames;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,7 +15,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -24,11 +26,11 @@ import java.util.Map;
 @Slf4j
 public class CustomAuthorizationFilter extends OncePerRequestFilter {
    private final BlacklistService blacklistService;
-   private final AuthenticationEntryPoint authenticationEntryPoint;
    private final CustomAuthorizationFilterHelper authorizationHelper;
-
-   private final String ACCESS_COOKIE = CookieNames.COOKIE_JWT_ACCESS.getValue();
-   private final String REFRESH_COOKIE = CookieNames.COOKIE_JWT_REFRESH.getValue();
+   private final RateLimiterService rateLimiterService;
+   private final TryCatchBlockExecutorService blockExecutorService;
+   private static final String REFRESH_COOKIE = CookieNames.COOKIE_JWT_REFRESH.getValue();
+   private static final String ACCESS_COOKIE = CookieNames.COOKIE_JWT_ACCESS.getValue();
 
    @Override
    protected void doFilterInternal(HttpServletRequest request,
@@ -36,40 +38,45 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
 
       log.info(request.getRequestURI());
-      final boolean authDoor = authorizationHelper.isAuthDoor(request);
-      if (authDoor) {
-         log.info("[FILTER] skipping: {}", request.getRequestURI());
-         filterChain.doFilter(request, response);
+      if (authorizationHelper.isAuthDoor(request)) {
+         blockExecutorService.executeVoidBlock(request, response, () -> {
+            rateLimiterService.fixedWindow(request);
+            filterChain.doFilter(request, response);
+         });
          return;
       }
 
-      final Map<String, String> cookies = authorizationHelper.extractCookiesFrom(request);
-      if (cookies.isEmpty()) return;
+      blockExecutorService.executeVoidBlock(request, response, () -> {
+         final Map<String, String> cookies = authorizationHelper.extractCookiesFrom(request);
+         if (cookies.isEmpty()) {
+            throw new AuthenticationNullException("There's no authentication.");
+         }
 
-      final String access = cookies.get(ACCESS_COOKIE);
-      if (access == null) {
-         authenticationEntryPoint.commence(request, response, new AccessExpiredException("Access expired."));
-      }
+         final String access = cookies.get(ACCESS_COOKIE);
+         if (access == null) {
+            throw new AccessExpiredException("Access expired.");
+         }
 
-      final String subject = authorizationHelper.extractSubject(access);
+         final String subject = authorizationHelper.extractSubject(access);
 
-      if (authorizationHelper.validateAccess(access, subject)) {
-         authorizationHelper.authorizeSubject(subject);
+         if (authorizationHelper.validateAccess(access, subject)) {
+            authorizationHelper.authorizeSubject(subject);
+            filterChain.doFilter(request, response);
+            return;
+         }
+
+         final String refresh = cookies.get(REFRESH_COOKIE);
+
+         if (blacklistService.isBlacklisted(refresh)) {
+            throw new TokenAlreadyBlacklistedException("Token already blacklisted.");
+         }
+
+         if (authorizationHelper.validateAccess(refresh, subject)) {
+            authorizationHelper.authorizeSubject(subject);
+            filterChain.doFilter(request, response);
+            return;
+         }
          filterChain.doFilter(request, response);
-         return;
-      }
-
-      final String refresh = cookies.get(REFRESH_COOKIE);
-
-      if (blacklistService.isBlacklisted(refresh)) {
-         authenticationEntryPoint.commence(request, response, new TokenAlreadyBlacklistedException("Token already blacklisted."));
-      }
-
-      if (authorizationHelper.validateAccess(refresh, subject)) {
-         authorizationHelper.authorizeSubject(subject);
-         filterChain.doFilter(request, response);
-         return;
-      }
-      filterChain.doFilter(request, response);
+      });
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/auth/helpers/CustomAuthorizationFilterHelper.java
+++ b/src/main/java/com/jame/dev/gymApp/auth/helpers/CustomAuthorizationFilterHelper.java
@@ -38,10 +38,11 @@ public class CustomAuthorizationFilterHelper {
       final Cookie[] cookies = Optional.ofNullable(request.getCookies())
               .orElseThrow(() -> new ServletException("unexisting cookies."));
 
-      return Arrays.stream(cookies).collect(
-              Collectors.toMap(
+      return Arrays.stream(cookies)
+              .collect(Collectors.toMap(
                       Cookie::getName,
-                      Cookie::getValue)
+                      Cookie::getValue
+              )
       );
    }
 

--- a/src/main/java/com/jame/dev/gymApp/config/app/RedisConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/config/app/RedisConfig.java
@@ -86,7 +86,7 @@ public class RedisConfig {
    }
 
    /**
-    * Scans the given package and searches for dto package ans sub packages inside and adds the mixIn there
+    * Scans the given package and searches for dto package and sub packages inside and adds the mixIn there
     * Requires a scan library or ClassPathScanningCandidateComponentProvider from Spring.
     */
    private void registerMixIns(ObjectMapper mapper, String basePackage) {
@@ -108,6 +108,22 @@ public class RedisConfig {
    @Bean(name = "tokensRedisTemplate")
    public StringRedisTemplate tokensBlacklister() {
       final JedisConnectionFactory factory = new JedisConnectionFactory(getStandaloneConfig(1));
+      factory.afterPropertiesSet();
+
+      return new StringRedisTemplate(factory);
+   }
+
+   @Bean("fixedWindowTemplate")
+   public StringRedisTemplate fixedWindowTemplate() {
+      final JedisConnectionFactory factory = new JedisConnectionFactory(getStandaloneConfig(2));
+      factory.afterPropertiesSet();
+
+      return new StringRedisTemplate(factory);
+   }
+
+   @Bean("blockingListTemplate")
+   public StringRedisTemplate blockingList() {
+      final JedisConnectionFactory factory = new JedisConnectionFactory(getStandaloneConfig(3));
       factory.afterPropertiesSet();
 
       return new StringRedisTemplate(factory);

--- a/src/main/java/com/jame/dev/gymApp/config/web/WebSecurityConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/config/web/WebSecurityConfig.java
@@ -52,7 +52,7 @@ public class WebSecurityConfig {
                       .anyRequest().authenticated()
               )
               .sessionManagement(session -> session
-                      .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                      .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
               .exceptionHandling(ex -> ex
                       .authenticationEntryPoint(customAuthenticationEntryPointHandler)
                       .accessDeniedHandler(customAccessDeniedHandler)

--- a/src/main/java/com/jame/dev/gymApp/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/advice/GlobalExceptionHandler.java
@@ -330,4 +330,23 @@ public class GlobalExceptionHandler {
               .buildResponse(new InputError(
                       ex, request, HttpStatus.BAD_REQUEST, ErrorCodes.VALIDATION));
    }
+
+   @ExceptionHandler(TooManyRequestsException.class)
+   public ResponseEntity<ApiErrorResponse> handleTooManyRequestsException(
+           TooManyRequestsException ex, HttpServletRequest request
+   ) {
+      return responseFactory
+              .buildResponse(new InputError(
+                      ex, request, HttpStatus.TOO_MANY_REQUESTS, ErrorCodes.ACCESS));
+   }
+
+
+   @ExceptionHandler(TemporaryBlockedException.class)
+   public ResponseEntity<ApiErrorResponse> handleTemporaryBlockedException(
+           TemporaryBlockedException ex, HttpServletRequest request
+   ) {
+      return responseFactory
+              .buildResponse(new InputError(
+                      ex, request, HttpStatus.LOCKED, ErrorCodes.ACCESS_DENIED));
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/auth/SessionController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/auth/SessionController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/session")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN') || hasRole('USER')")
 public class SessionController {
 
    private final SessionService sessionService;

--- a/src/main/java/com/jame/dev/gymApp/exception/TemporaryBlockedException.java
+++ b/src/main/java/com/jame/dev/gymApp/exception/TemporaryBlockedException.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.exception;
+
+public class TemporaryBlockedException extends RuntimeException {
+   public TemporaryBlockedException(String message) {
+      super(message);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/exception/TooManyRequestsException.java
+++ b/src/main/java/com/jame/dev/gymApp/exception/TooManyRequestsException.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.exception;
+
+public class TooManyRequestsException extends RuntimeException {
+   public TooManyRequestsException(String message) {
+      super(message);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/service/in/BlockingService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/in/BlockingService.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.service.in;
+
+import java.time.Duration;
+
+public interface BlockingService {
+   void blockTemporary(String blockingKey, String strikeKey);
+   boolean isBlocked(String  blockingKey);
+   Duration getBlockingTimeOf(String blockingKey);
+}

--- a/src/main/java/com/jame/dev/gymApp/service/in/RateLimiterService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/in/RateLimiterService.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.service.in;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * This interface is a collection of all the
+ * algorithms to perform some kind of R.L technics.
+ */
+public interface RateLimiterService {
+   void fixedWindow(final HttpServletRequest request);
+}

--- a/src/main/java/com/jame/dev/gymApp/service/in/TryCatchBlockExecutorService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/in/TryCatchBlockExecutorService.java
@@ -1,0 +1,18 @@
+package com.jame.dev.gymApp.service.in;
+
+import com.jame.dev.gymApp.shared.interfaces.VoidBlock;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface TryCatchBlockExecutorService {
+   /**
+    * Runs code-block and delegates the exception on failure to the
+    * GlobalExceptionHandler.
+    * Should be used on Filters, handlers, etc.
+    */
+   void executeVoidBlock(
+           HttpServletRequest request,
+           HttpServletResponse response,
+           VoidBlock block
+   );
+}

--- a/src/main/java/com/jame/dev/gymApp/service/out/BlockingListServiceImp.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/BlockingListServiceImp.java
@@ -1,0 +1,45 @@
+package com.jame.dev.gymApp.service.out;
+
+import com.jame.dev.gymApp.service.in.BlockingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class BlockingListServiceImp implements BlockingService {
+   private final StringRedisTemplate blockingListTemplate;
+
+   private static final int BASE_BLOCK_MINUTES = 5;
+   private static final int BASE_TTL_STRIKE_HOURS = 24;
+
+   @Override
+   public void blockTemporary(final String blockingKey, final String strikeKey) {
+      final Long currentStrikes = blockingListTemplate.opsForValue().increment(strikeKey);
+
+      if (currentStrikes != null && currentStrikes == 1) {
+         blockingListTemplate.expire(strikeKey, Duration.ofHours(BASE_TTL_STRIKE_HOURS));
+      }
+
+      final long blockDurationMinutes =
+              (long) BASE_BLOCK_MINUTES * (currentStrikes != null ? currentStrikes : 1);
+
+      blockingListTemplate.opsForValue().set(
+              blockingKey,
+              "Temporary Locked.",
+              Duration.ofMinutes(blockDurationMinutes));
+   }
+
+   @Override
+   public boolean isBlocked(final String blockingKey) {
+      return blockingListTemplate.hasKey(blockingKey);
+   }
+
+   @Override
+   public Duration getBlockingTimeOf(String blockingKey) {
+      final long expiration = blockingListTemplate.getExpire(blockingKey);
+      return expiration > 0 ? Duration.ofMinutes(expiration) : Duration.ZERO;
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/service/out/RateLimiterServiceImp.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/RateLimiterServiceImp.java
@@ -1,0 +1,52 @@
+package com.jame.dev.gymApp.service.out;
+
+import com.jame.dev.gymApp.exception.TemporaryBlockedException;
+import com.jame.dev.gymApp.exception.TooManyRequestsException;
+import com.jame.dev.gymApp.service.in.BlockingService;
+import com.jame.dev.gymApp.service.in.RateLimiterService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RateLimiterServiceImp implements RateLimiterService {
+   private final StringRedisTemplate fixedWindowTemplate;
+   private final BlockingService blockingService;
+
+   private static final int WINDOW_REQUESTS = 5;
+   private static final int WINDOW_SIZE_SECONDS = 60;
+
+   @Override
+   public void fixedWindow(final HttpServletRequest request) {
+      final String clientIp = request.getRemoteAddr();
+
+      final String key = "rl:auth:" + clientIp;
+
+      if (blockingService.isBlocked(key)) {
+         final Duration blockingTime = blockingService.getBlockingTimeOf(key);
+
+         final String timeLeft = String.format("%d:%02d",
+                 blockingTime.toHours(),
+                 blockingTime.toMinutesPart());
+         throw new TemporaryBlockedException(
+                 String.format("Account locked. %s until get unlocked", timeLeft)
+         );
+      }
+
+      final Long currentCount = fixedWindowTemplate.opsForValue().increment(key);
+
+      if (currentCount != null && currentCount == 1) {
+         fixedWindowTemplate.expire(key, Duration.ofSeconds(WINDOW_SIZE_SECONDS));
+      }
+
+      if (currentCount != null && currentCount > WINDOW_REQUESTS) {
+         final String strikeKey = key + ":struck";
+         blockingService.blockTemporary(key, strikeKey);
+         throw new TooManyRequestsException("Too many request to the resource.");
+      }
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/service/out/TryCatchBlockExecutorServiceImp.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/TryCatchBlockExecutorServiceImp.java
@@ -1,0 +1,27 @@
+package com.jame.dev.gymApp.service.out;
+
+import com.jame.dev.gymApp.service.in.TryCatchBlockExecutorService;
+import com.jame.dev.gymApp.shared.interfaces.VoidBlock;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Service
+@RequiredArgsConstructor
+public class TryCatchBlockExecutorServiceImp implements TryCatchBlockExecutorService {
+   private final HandlerExceptionResolver handlerExceptionResolver;
+
+   @Override
+   public void executeVoidBlock(@NonNull HttpServletRequest request,
+                                @NonNull HttpServletResponse response,
+                                VoidBlock block) {
+      try {
+         block.execute();
+      } catch (Exception e) {
+         handlerExceptionResolver.resolveException(request, response, null, e);
+      }
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/shared/interfaces/VoidBlock.java
+++ b/src/main/java/com/jame/dev/gymApp/shared/interfaces/VoidBlock.java
@@ -1,0 +1,6 @@
+package com.jame.dev.gymApp.shared.interfaces;
+
+@FunctionalInterface
+public interface VoidBlock {
+   void execute() throws Exception;
+}

--- a/src/test/java/com/jame/dev/gymApp/service/BlockingServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/BlockingServiceTest.java
@@ -1,0 +1,85 @@
+package com.jame.dev.gymApp.service;
+
+
+import com.jame.dev.gymApp.service.out.BlockingListServiceImp;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class BlockingServiceTest {
+
+   @Mock
+   StringRedisTemplate blockingListTemplate;
+
+   @Mock
+   ValueOperations<String, String> valueOperations;
+
+   @InjectMocks
+   BlockingListServiceImp service;
+
+   @Test
+   @DisplayName("Should block a given blockingKey")
+   void shouldBlockGivenKey() {
+      String blockingKey = "rl:auth:127.0.0.1";
+      String strikeKey = blockingKey + ":struck";
+
+      given(blockingListTemplate.opsForValue()).willReturn(valueOperations);
+      given(valueOperations.increment(anyString()))
+              .willReturn(1L);
+      given(blockingListTemplate.expire(anyString(), any(Duration.class)))
+              .willReturn(true);
+      willDoNothing().given(valueOperations).set(anyString(), any(), any(Duration.class));
+
+      service.blockTemporary(blockingKey, strikeKey);
+
+      verify(blockingListTemplate, atLeast(2)).opsForValue();
+      verify(valueOperations).increment(anyString());
+      verify(blockingListTemplate).expire(anyString(), any(Duration.class));
+      verify(valueOperations).set(anyString(), any(), any(Duration.class));
+
+      verifyNoMoreInteractions(blockingListTemplate, valueOperations);
+   }
+
+   @Test
+   @DisplayName("Should indicate whether a key is blocked.")
+   void shouldIndicatesBlockedStatusOfBlockedKey() {
+      String blockingKey = "rl:auth:127.0.0.1";
+      given(blockingListTemplate.hasKey(anyString()))
+              .willReturn(true);
+
+      assertTrue(service.isBlocked(blockingKey));
+
+      verify(blockingListTemplate).hasKey(anyString());
+      verifyNoMoreInteractions(blockingListTemplate);
+   }
+
+   @Test
+   @DisplayName("Should retrieves the duration from a given key")
+   void shouldReturnTheDuration() {
+      String blockingKey = "rl:auth:127.0.0.1";
+      given(blockingListTemplate.getExpire(anyString()))
+              .willReturn(10_000L);
+      assertNotNull(service.getBlockingTimeOf(blockingKey));
+
+      verify(blockingListTemplate).getExpire(blockingKey);
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/service/RateLimiterServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/RateLimiterServiceTest.java
@@ -1,0 +1,112 @@
+package com.jame.dev.gymApp.service;
+
+import com.jame.dev.gymApp.exception.TemporaryBlockedException;
+import com.jame.dev.gymApp.exception.TooManyRequestsException;
+import com.jame.dev.gymApp.service.in.BlockingService;
+import com.jame.dev.gymApp.service.out.RateLimiterServiceImp;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class RateLimiterServiceTest {
+
+   @Mock
+   StringRedisTemplate fixedListTemplate;
+   @Mock
+   BlockingService blockingService;
+   @Mock
+   ValueOperations<String, String> valueOperations;
+
+   @InjectMocks
+   RateLimiterServiceImp service;
+
+   @Test
+   @DisplayName("Should throws TooManyRequestException and block user when limit is exceeded")
+   void shouldThrowsTooManyRequestException() {
+      long requestCount = 6;
+      String ip = "127.0.0.1";
+      var request = mock(HttpServletRequest.class);
+      given(request.getRemoteAddr()).willReturn(ip);
+
+      given(fixedListTemplate.opsForValue()).willReturn(valueOperations);
+      given(valueOperations.increment(anyString())).willReturn(requestCount);
+
+      given(blockingService.isBlocked(anyString())).willReturn(false);
+
+      willDoNothing().given(blockingService).blockTemporary(anyString(), anyString());
+
+      assertThrows(TooManyRequestsException.class, () -> service.fixedWindow(request));
+
+      verify(blockingService).isBlocked(anyString());
+      verify(fixedListTemplate).opsForValue();
+      verify(valueOperations).increment(anyString());
+      verify(blockingService).blockTemporary(anyString(), anyString());
+
+      verifyNoMoreInteractions(blockingService, fixedListTemplate, valueOperations);
+   }
+
+   @Test
+   @DisplayName("Should throws TemporaryBlockedException")
+   void shouldThrowsTemporaryBlockedException() {
+      String ip = "127.0.0.1";
+      var request = mock(HttpServletRequest.class);
+      given(request.getRemoteAddr()).willReturn(ip);
+
+      given(blockingService.isBlocked(anyString()))
+              .willReturn(true);
+      given(blockingService.getBlockingTimeOf(anyString()))
+              .willReturn(Duration.ofMinutes(5));
+
+      assertThrows(TemporaryBlockedException.class, () -> service.fixedWindow(request));
+
+      verify(blockingService).isBlocked(anyString());
+      verify(blockingService).getBlockingTimeOf(anyString());
+      verifyNoMoreInteractions(blockingService);
+      verifyNoInteractions(fixedListTemplate, valueOperations);
+   }
+
+   @Test
+   @DisplayName("Should sets the key and expiration without throwing anything")
+   void shouldStoreTheKey() {
+      String ip = "127.0.0.1";
+      var request = mock(HttpServletRequest.class);
+
+      given(request.getRemoteAddr()).willReturn(ip);
+      given(fixedListTemplate.opsForValue())
+              .willReturn(valueOperations);
+      given(valueOperations.increment(anyString()))
+              .willReturn(1L);
+      given(blockingService.isBlocked(anyString()))
+              .willReturn(false);
+      given(fixedListTemplate.expire(anyString(), any(Duration.class)))
+              .willReturn(true);
+
+      assertDoesNotThrow(() -> service.fixedWindow(request));
+
+      verify(fixedListTemplate).opsForValue();
+      verify(valueOperations).increment(anyString());
+      verify(blockingService).isBlocked(anyString());
+      verify(fixedListTemplate).expire(anyString(), any(Duration.class));
+      verifyNoMoreInteractions(blockingService, fixedListTemplate, valueOperations);
+   }
+
+}


### PR DESCRIPTION
### Main Changes

***Service***
 - > Created RateLimiterService which is an interface that it's to define whatever method that represent a rate limiter technique.
 - > Created BlockingListService, in this case this was designed to give some coverage to the Fixed Window tecnique, which is used on RateLimiterService, to avoid issues like: 'users has been requested 100 times on the first 10 seconds', with this the account is limited only to 5 request any resource on /auth under 5 minutes.

### Minimal Changes
***Service***
-> The following interfaces were been defined: 
```
@FunctionalInterface
public interface VoidBlock {
   void execute() throws Exception;
}
```
```
public interface TryCatchBlockExecutorService {
   void executeVoidBlock(
           HttpServletRequest request,
           HttpServletResponse response,
           VoidBlock block
   );
}
```
- > With the purpose of throw exceptions from the Filter without using another components or beans and repeat the same logic over and over just to throwing an exception. This automatically runs the code and handles the Exception if any and notifies the GlobalExceptionHandler to throw it. Now in the Filter you just throw an Exception and it will be sent to the client correctly.  