### PR TITLE
Cache De/serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <lombok.version>1.18.42</lombok.version>
     <org.mapstruct.version>1.6.3</org.mapstruct.version>
     <io.jsonwebtoken.version>0.13.0</io.jsonwebtoken.version>
+    <jackson.version>2.21.1</jackson.version>
   </properties>
   <dependencies>
     <dependency>
@@ -61,28 +62,28 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-redis</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
 
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-websocket</artifactId>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-parameter-names</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/jame/dev/gymApp/config/app/RedisConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/config/app/RedisConfig.java
@@ -1,11 +1,14 @@
 package com.jame.dev.gymApp.config.app;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.jame.dev.gymApp.model.mixIn.DefaultMixInDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,43 +55,78 @@ public class RedisConfig {
    @Bean
    public PolymorphicTypeValidator getPolymorphicTypeValidator() {
       return BasicPolymorphicTypeValidator.builder()
-              .allowIfSubType("com.jame.dev.gymApp")
-              .allowIfSubType("org.springframework.data.domain")
-              .allowIfBaseType(java.util.Collection.class)
-              .allowIfBaseType(java.util.Map.class)
-              .allowIfBaseType(java.time.temporal.Temporal.class)
-              .allowIfBaseType(java.lang.Number.class)
-              .allowIfBaseType(Object.class)
-              .build();
+         .allowIfSubType("com.jame.dev.gymApp")
+         .allowIfSubType("org.springframework.data.domain")
+         .allowIfBaseType(java.util.Collection.class)
+         .allowIfBaseType(java.util.Map.class)
+         .allowIfBaseType(java.time.temporal.Temporal.class)
+         .allowIfBaseType(java.lang.Number.class)
+         .allowIfBaseType(Object.class)
+         .allowIfBaseType(Record.class)
+         .build();
    }
 
    @Bean("redisCacheManager")
    public CacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
-      final PolymorphicTypeValidator ptv = getPolymorphicTypeValidator();
       final ObjectMapper redisMapper = new ObjectMapper();
-      registerMixIns(redisMapper, "com.jame.dev.gymApp");
 
-      redisMapper.registerModule(new JavaTimeModule())
-              .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-              .activateDefaultTyping(
-                      ptv,
-                      ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE,
-                      JsonTypeInfo.As.PROPERTY
-              );
+      redisMapper.registerModules(
+         new JavaTimeModule(),
+         new ParameterNamesModule(),
+         new Jdk8Module()
+      ).findAndRegisterModules();
 
-      RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-              .prefixCacheNameWith("gym-app:")
-              .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-              .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(redisMapper)))
-              .entryTtl(Duration.ofMinutes(10));
+      redisMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-      return RedisCacheManager.builder(connectionFactory).cacheDefaults(config).build();
+      redisMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+      registerMixIns(redisMapper);
+
+      final PolymorphicTypeValidator ptv = getPolymorphicTypeValidator();
+
+      redisMapper.activateDefaultTyping(
+         ptv,
+         ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE,
+         JsonTypeInfo.As.PROPERTY
+      );
+
+      final RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+         .prefixCacheNameWith("gym-app:")
+         .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(
+               new StringRedisSerializer()
+            )
+         )
+         .serializeValuesWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(
+               new GenericJackson2JsonRedisSerializer(redisMapper)
+            )
+         )
+         .entryTtl(Duration.ofMinutes(5))
+         .disableCachingNullValues();
+
+      return RedisCacheManager.builder(connectionFactory)
+         .cacheDefaults(config)
+         .build();
    }
 
-   /**
-    * Scans the given package and searches for dto package and sub packages inside and adds the mixIn there
-    * Requires a scan library or ClassPathScanningCandidateComponentProvider from Spring.
-    */
+
+   private void registerMixIns(ObjectMapper mapper) {
+      ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+      scanner.addIncludeFilter(new AssignableTypeFilter(Object.class));
+
+      scanner.findCandidateComponents("com.jame.dev.gymApp").forEach(beanDefinition -> {
+         try {
+            Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
+            if (clazz.isRecord() && clazz.getName().contains(".dto.")) {
+               mapper.addMixIn(clazz, DefaultMixInDto.class);
+            }
+         } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e.getMessage(), e);
+         }
+      });
+   }
+
    private void registerMixIns(ObjectMapper mapper, String basePackage) {
       ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
       scanner.addIncludeFilter(new AssignableTypeFilter(Object.class));
@@ -96,11 +134,11 @@ public class RedisConfig {
       scanner.findCandidateComponents(basePackage).forEach(beanDefinition -> {
          try {
             Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
-            if (clazz.isRecord() || clazz.getName().contains(".dto.")) {
+            if (clazz.isRecord() && clazz.getName().contains(".dto.")) {
                mapper.addMixIn(clazz, DefaultMixInDto.class);
             }
          } catch (ClassNotFoundException e) {
-            log.error("{}", e.getMessage());
+            throw new RuntimeException(e.getMessage(), e);
          }
       });
    }

--- a/src/main/java/com/jame/dev/gymApp/controller/service/BaseController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/service/BaseController.java
@@ -2,7 +2,6 @@ package com.jame.dev.gymApp.controller.service;
 
 import com.jame.dev.gymApp.aspects.annotations.constraints.Minimum;
 import com.jame.dev.gymApp.aspects.annotations.constraints.NotNullObject;
-import com.jame.dev.gymApp.exception.EntityNotFoundException;
 import com.jame.dev.gymApp.model.dto.out.PageDto;
 import com.jame.dev.gymApp.service.common.BaseService;
 import jakarta.validation.Valid;
@@ -38,9 +37,8 @@ public abstract class BaseController<OUT, IN> {
    }
 
    protected ResponseEntity<@NonNull OUT> getOne(final long id) {
-      final OUT response = service.getById(id)
-              .orElseThrow(() -> new EntityNotFoundException("Not found id: " + id));
-      return ResponseEntity.ok(response);
+      final OUT body = service.getById(id);
+      return ResponseEntity.ok(body);
    }
 
    protected ResponseEntity<@NonNull OUT> create(final IN dto) {

--- a/src/main/java/com/jame/dev/gymApp/service/common/BaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/common/BaseService.java
@@ -7,14 +7,12 @@ import jakarta.validation.Valid;
 import lombok.NonNull;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Optional;
-
 public interface BaseService<DTO_OUT, DTO_IN> {
    PageDto<@NonNull DTO_OUT> getPage(@NotNullObject @Valid final Pageable pageable);
 
    DTO_OUT save(@NotNullObject @Valid final DTO_IN dtoIn);
 
-   Optional<DTO_OUT> getById(@Minimum final long id);
+   DTO_OUT getById(@Minimum final long id);
 
    DTO_OUT update(@Minimum final long id, @NotNullObject @Valid final DTO_IN dtoIn);
 

--- a/src/main/java/com/jame/dev/gymApp/service/out/CustomerServiceImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/CustomerServiceImplementation.java
@@ -50,13 +50,11 @@ public class CustomerServiceImplementation implements CustomerService {
 
    @Override
    @Transactional(readOnly = true)
-   @Cacheable(
-      value = CacheValues.CUSTOMER, key = "#id",
-      unless = "#result == null || !#result.isPresent()"
-   )
-   public Optional<CustomerDtoOutput> getById(long id) {
+   @Cacheable(value = CacheValues.CUSTOMER, key = "#id")
+   public CustomerDtoOutput getById(long id) {
       return repo.findById(id)
-         .map(customerFactory::createFromEntity);
+         .map(customerFactory::createFromEntity)
+         .orElseThrow(() -> new CustomerNotFoundException("Customer Not found."));
    }
 
    @Override

--- a/src/main/java/com/jame/dev/gymApp/service/out/SubscriptionServiceImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/SubscriptionServiceImplementation.java
@@ -83,13 +83,11 @@ public class SubscriptionServiceImplementation implements SubscriptionService {
 
    @Override
    @Transactional(readOnly = true)
-   @Cacheable(
-      value = CacheValues.SUBSCRIPTION, key = "#id",
-      unless = "#result == null || !#result.isPresent()"
-   )
-   public Optional<SubscriptionDtoOutput> getById(long id) {
+   @Cacheable(value = CacheValues.SUBSCRIPTION, key = "#id")
+   public SubscriptionDtoOutput getById(long id) {
       return repo.findById(id)
-         .map(subscriptionFactory::createFromEntity);
+         .map(subscriptionFactory::createFromEntity)
+         .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not found."));
    }
 
    @Transactional(readOnly = true)

--- a/src/main/java/com/jame/dev/gymApp/service/out/UserServiceImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/UserServiceImplementation.java
@@ -70,13 +70,11 @@ public class UserServiceImplementation implements UserService {
 
    @Override
    @Transactional(readOnly = true)
-   @Cacheable(
-      value = CacheValues.USER, key = "#id",
-      unless = "#result == null || !#result.isPresent()"
-   )
-   public Optional<UserDtoOutput> getById(long id) {
+   @Cacheable(value = CacheValues.USER, key = "#id")
+   public UserDtoOutput getById(long id) {
       return repo.findById(id)
-         .map(userFactory::createFromEntity);
+         .map(userFactory::createFromEntity)
+         .orElseThrow(() -> new UserEntityNotFoundException("User not found."));
    }
 
    @Override

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/CustomerControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/CustomerControllerTest.java
@@ -33,7 +33,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.Optional;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -118,7 +117,7 @@ class CustomerControllerTest {
       @DisplayName("GET[200] OK: get customer /customers/{id}")
       void getCustomer() throws Exception {
          given(customerService.getById(anyLong()))
-            .willReturn(Optional.of(customerDtoOutput));
+            .willReturn(customerDtoOutput);
          mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 1L)
                .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -127,10 +126,10 @@ class CustomerControllerTest {
       }
 
       @Test
-      @DisplayName("GET[400] Not Found: get customer /customers/{id}")
+      @DisplayName("GET[404] Not Found: get customer /customers/{id}")
       void customerNotFound() throws Exception {
          given(customerService.getById(anyLong()))
-            .willReturn(Optional.empty());
+            .willThrow(CustomerNotFoundException.class);
          mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 100L)
                .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionControllerTest.java
@@ -37,7 +37,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -129,7 +128,7 @@ public class SubscriptionControllerTest {
       @DisplayName("GET[200] OK: get sub /subs/{id}")
       void getSubscription() throws Exception {
          given(subscriptionService.getById(anyLong()))
-            .willReturn(Optional.of(subscriptionDtoOutput));
+            .willReturn(subscriptionDtoOutput);
          mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 1L)
                .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -138,10 +137,10 @@ public class SubscriptionControllerTest {
       }
 
       @Test
-      @DisplayName("GET[400] Not Found: get sub /subs/{id}")
+      @DisplayName("GET[404] Not Found: get sub /subs/{id}")
       void subscriptionNotFound() throws Exception {
          given(subscriptionService.getById(anyLong()))
-            .willReturn(Optional.empty());
+            .willThrow(SubscriptionNotFoundException.class);
          mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 100L)
                .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/UserControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/UserControllerTest.java
@@ -33,7 +33,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.Optional;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -120,7 +119,7 @@ public class UserControllerTest {
       @DisplayName("GET[200] OK: get users /users/{id}")
       void getUser() throws Exception {
          given(userService.getById(anyLong()))
-            .willReturn(Optional.of(userDto));
+            .willReturn(userDto);
          mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 1L)
                .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -129,10 +128,10 @@ public class UserControllerTest {
       }
 
       @Test
-      @DisplayName("GET[400] Not Found: get user /users/{id}")
-      void customerNotFound() throws Exception {
+      @DisplayName("GET[404] Not Found: get user /users/{id}")
+      void userNotFound() throws Exception {
          given(userService.getById(anyLong()))
-            .willReturn(Optional.empty());
+            .willThrow(UserNotFoundException.class);
          mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 100L)
                .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound())

--- a/src/test/java/com/jame/dev/gymApp/service/CustomerServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/CustomerServiceTest.java
@@ -106,11 +106,7 @@ public class CustomerServiceTest {
               .thenReturn(output);
 
       final var result = assertDoesNotThrow(() -> service.getById(1L));
-
-
-      assertTrue(result.isPresent(), "The result should not be empty");
-      assertDoesNotThrow(result::get, "Shouldn't throw any Exception.");
-      assertNotNull(result.get(), "The result should not be null.");
+      assertNotNull(result);
 
       verify(repo, times(1)).findById(anyLong());
       verify(customerFactory, times(1)).createFromEntity(any());
@@ -132,7 +128,6 @@ public class CustomerServiceTest {
    void saveCustomer() {
       UserEntity user = mock();
       CustomerEntity customer = mock();
-      when(user.isActive()).thenReturn(true);
 
       CustomerDtoOutput output =  mock(CustomerDtoOutput.class);
 

--- a/src/test/java/com/jame/dev/gymApp/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/SubscriptionServiceTest.java
@@ -70,24 +70,24 @@ class SubscriptionServiceTest {
    private final SubscriptionEntity mockSubscription = new SubscriptionEntity();
 
    private final List<SubscriptionEntity> testSubsList = IntStream.range(0, 10)
-           .mapToObj(i -> {
-              CustomerEntity customer = new CustomerEntity(
-                      new UserEntity(), "32472525" + i);
-              PricingEntity pricing = new PricingEntity(
-                      (i + 1),
-                      new MemberShipEntity(
-                              (i + 1),
-                              Membership.MONTHLY),
-                      BigDecimal.valueOf(300.00d)
-              );
-              return SubscriptionEntity.builder()
-                      .customer(customer)
-                      .pricing(pricing)
-                      .subscriptionPeriods(List.of(new PeriodEntity()))
-                      .finished(false)
-                      .build();
-           })
-           .toList();
+      .mapToObj(i -> {
+         CustomerEntity customer = new CustomerEntity(
+            new UserEntity(), "32472525" + i);
+         PricingEntity pricing = new PricingEntity(
+            (i + 1),
+            new MemberShipEntity(
+               (i + 1),
+               Membership.MONTHLY),
+            BigDecimal.valueOf(300.00d)
+         );
+         return SubscriptionEntity.builder()
+            .customer(customer)
+            .pricing(pricing)
+            .subscriptionPeriods(List.of(new PeriodEntity()))
+            .finished(false)
+            .build();
+      })
+      .toList();
 
    @BeforeEach
    void setUp() {
@@ -121,12 +121,11 @@ class SubscriptionServiceTest {
       SubscriptionDtoOutput output = mock();
       when(repo.findById(anyLong())).thenReturn(Optional.of(new SubscriptionEntity()));
       when(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class)))
-              .thenReturn(output);
+         .thenReturn(output);
 
       final var result = assertDoesNotThrow(() -> service.getById(anyLong()));
 
-      assertTrue(result.isPresent(), "Result should be present.");
-      assertNotNull(result.get(), "Result shouldn't be null.");
+      assertNotNull(result, "Result shouldn't be null.");
 
       verify(repo, atMostOnce()).findById(anyLong());
       verify(subscriptionFactory, atMostOnce()).createFromEntity(any());
@@ -142,17 +141,17 @@ class SubscriptionServiceTest {
       SubscriptionEntity subscriptionMock = mock(SubscriptionEntity.class);
 
       when(customerRepo.findByUser_Email(anyString()))
-              .thenReturn(Optional.of(customerMock));
+         .thenReturn(Optional.of(customerMock));
       when(repo.existsByCustomer(any(CustomerEntity.class)))
-              .thenReturn(false);
+         .thenReturn(false);
       when(pricingRepo.findByMemberShipEntity_Membership(any(Membership.class)))
-              .thenReturn(Optional.of(pricingMock));
+         .thenReturn(Optional.of(pricingMock));
       when(subscriptionFactory.createFromInput(any(SubscriptionFactoryDtoInput.class)))
-              .thenReturn(subscriptionMock);
+         .thenReturn(subscriptionMock);
       when(repo.saveAndFlush(any(SubscriptionEntity.class)))
-              .thenReturn(subscriptionMock);
+         .thenReturn(subscriptionMock);
       when(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class)))
-              .thenReturn(output);
+         .thenReturn(output);
 
       final var result = assertDoesNotThrow(() -> service.save(this.dtoMock));
 
@@ -162,7 +161,7 @@ class SubscriptionServiceTest {
       verify(repo, atMostOnce()).existsByCustomer(any(CustomerEntity.class));
       verify(pricingRepo, atMostOnce()).findByMemberShipEntity_Membership(any(Membership.class));
       verify(subscriptionFactory, atMostOnce())
-              .createFromInput(any(SubscriptionFactoryDtoInput.class));
+         .createFromInput(any(SubscriptionFactoryDtoInput.class));
       verify(repo, atLeastOnce()).saveAndFlush(any(SubscriptionEntity.class));
       verify(subscriptionFactory, atMostOnce()).createFromEntity(any(SubscriptionEntity.class));
       verifyNoMoreInteractions(repo, customerRepo, pricingRepo, subscriptionFactory);
@@ -200,17 +199,17 @@ class SubscriptionServiceTest {
       subscriptionEntity.setUpdatedAt(Instant.now());
 
       when(repo.findById(anyLong()))
-              .thenReturn(Optional.of(subscriptionEntity));
+         .thenReturn(Optional.of(subscriptionEntity));
       when(pricingRepo.findByMemberShipEntity_Membership(any(Membership.class)))
-              .thenReturn(Optional.of(new PricingEntity()));
+         .thenReturn(Optional.of(new PricingEntity()));
       doNothing().when(subscriptionUpdater).apply(
-              any(SubscriptionEntity.class),
-              any(PricingEntity.class)
+         any(SubscriptionEntity.class),
+         any(PricingEntity.class)
       );
       when(repo.saveAndFlush(any(SubscriptionEntity.class))).
-              thenReturn(subscriptionEntity);
+         thenReturn(subscriptionEntity);
       when(subscriptionFactory.createFromEntity(any()))
-              .thenReturn(output);
+         .thenReturn(output);
 
       assertDoesNotThrow(() -> service.update(1L, dtoMock), "Should doesn't throw any exception");
 
@@ -231,11 +230,11 @@ class SubscriptionServiceTest {
       SubscriptionDtoOutput output = mock(SubscriptionDtoOutput.class);
 
       when(repo.findById(anyLong()))
-              .thenReturn(Optional.of(new SubscriptionEntity()));
+         .thenReturn(Optional.of(new SubscriptionEntity()));
       when(repo.saveAndFlush(any(SubscriptionEntity.class)))
-              .thenReturn(subscriptionEntity);
+         .thenReturn(subscriptionEntity);
       when(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class)))
-              .thenReturn(output);
+         .thenReturn(output);
 
       final var result = assertDoesNotThrow(() -> service.patch(1L));
       assertNotNull(result);
@@ -257,9 +256,9 @@ class SubscriptionServiceTest {
       when(validator.validateOnRenew(anyLong(), any(SubscriptionDtoInput.class)))
          .thenReturn(subscription);
       when(pricingRepo.findByMemberShipEntity_Membership(any(Membership.class)))
-              .thenReturn(Optional.of(pricingMock));
+         .thenReturn(Optional.of(pricingMock));
       doNothing().when(subscriptionUpdater)
-              .applyRenew(any(SubscriptionEntity.class), any(PricingEntity.class));
+         .applyRenew(any(SubscriptionEntity.class), any(PricingEntity.class));
       when(repo.saveAndFlush(any(SubscriptionEntity.class))).thenReturn(subscription);
       when(subscriptionFactory.createFromEntity(any())).thenReturn(output);
 

--- a/src/test/java/com/jame/dev/gymApp/service/UserServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/UserServiceTest.java
@@ -94,8 +94,7 @@ public class UserServiceTest {
               .thenReturn(output);
       final var result = assertDoesNotThrow(() -> service.getById(1L));
 
-      assertTrue(result.isPresent(), "Result optional should be present.");
-      assertNotNull(result.get(), "Result should not be null");
+      assertNotNull(result, "Result should not be null");
 
       verify(repo, atLeastOnce()).findById(anyLong());
       verify(userFactory, atLeastOnce()).createFromEntity(any());


### PR DESCRIPTION
### Main changes

***Cache Manager***

- Changed usages where Optional values were caching by `@Cacheable` annotation, more in concrete Service implementation classes, cause now in `jedis 7.4` serialize and deserialize Optional or null values is and anti-pattern, so `getById` **BaseService** method have changed to return the `OUT` object instead of `Optional<OUT>`.
- The related Tests has been adapted to this change.