### PR TITLE
Password Recovery

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/aspects/annotations/aspects/PublishPasswordResetRequest.java
+++ b/src/main/java/com/jame/dev/gymApp/aspects/annotations/aspects/PublishPasswordResetRequest.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.aspects.annotations.aspects;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PublishPasswordResetRequest {
+}

--- a/src/main/java/com/jame/dev/gymApp/aspects/imp/aspects/PublisherPasswordResetRequestAspect.java
+++ b/src/main/java/com/jame/dev/gymApp/aspects/imp/aspects/PublisherPasswordResetRequestAspect.java
@@ -1,0 +1,28 @@
+package com.jame.dev.gymApp.aspects.imp.aspects;
+
+import com.jame.dev.gymApp.model.dto.in.RecoveryRequest;
+import com.jame.dev.gymApp.model.listeners.PasswordResetEvent;
+import com.jame.dev.gymApp.service.in.TokenGeneratorService;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class PublisherPasswordResetRequestAspect {
+   private final ApplicationEventPublisher applicationEventPublisher;
+   private final TokenGeneratorService tokenGeneratorService;
+
+   @Before("@annotation(com.jame.dev.gymApp.aspects.annotations.aspects.PublishPasswordResetRequest) && args(recoveryRequest)")
+   public void publishPasswordResetRequest(final RecoveryRequest recoveryRequest) {
+      applicationEventPublisher.publishEvent(
+         new PasswordResetEvent(
+            recoveryRequest.email(),
+            tokenGeneratorService.generateTokenOneTimeToken()
+         )
+      );
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/config/web/WebSecurityConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/config/web/WebSecurityConfig.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -48,8 +47,7 @@ public class WebSecurityConfig {
             corsConfig.configurationSourceDev())
          )
          .authorizeHttpRequests(auth -> auth
-            .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
-            .requestMatchers(HttpMethod.PATCH, "/auth/verify/**").permitAll()
+            .requestMatchers("/auth/**").permitAll()
             .requestMatchers("/oauth2/**", "/login/oauth2/**", "/oauth2/authorization/**").permitAll()
             .requestMatchers("/error").permitAll()
             .requestMatchers("/favicon.ico").permitAll()
@@ -93,8 +91,7 @@ public class WebSecurityConfig {
          .csrf(AbstractHttpConfigurer::disable)
          .cors(cors -> cors.configurationSource(corsConfig.configurationSourceProd()))
          .authorizeHttpRequests(auth -> auth
-            .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
-            .requestMatchers(HttpMethod.PATCH, "/auth/verify/**").permitAll()
+            .requestMatchers("/auth/**").permitAll()
             .requestMatchers("/oauth2/**", "/login/oauth2/**", "/oauth2/authorization/**").permitAll()
             .requestMatchers("/error").permitAll()
             .requestMatchers("/favicon.ico").permitAll()

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/auth/PasswordResetController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/auth/PasswordResetController.java
@@ -1,0 +1,62 @@
+package com.jame.dev.gymApp.controller.routes.auth;
+
+import com.jame.dev.gymApp.aspects.annotations.aspects.PublishPasswordResetRequest;
+import com.jame.dev.gymApp.aspects.annotations.constraints.Minimum;
+import com.jame.dev.gymApp.aspects.annotations.constraints.NotEmptyNull;
+import com.jame.dev.gymApp.model.dto.auth.TokenIdResetPasswordRequest;
+import com.jame.dev.gymApp.model.dto.in.PasswordResetDtoInput;
+import com.jame.dev.gymApp.model.dto.in.RecoveryRequest;
+import com.jame.dev.gymApp.service.in.OneTimeTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_FOUND;
+
+@RequestMapping("/auth/passwords")
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class PasswordResetController {
+   private final OneTimeTokenService oneTimeTokenService;
+
+   @PostMapping("/request-reset")
+   @PublishPasswordResetRequest
+   public ResponseEntity<Void> requestReset(
+      @RequestBody @Valid RecoveryRequest ignored
+   ) {
+      return ResponseEntity.accepted().build();
+   }
+
+   @GetMapping("/reset")
+   public ResponseEntity<Void> resetPassword(
+      @Valid
+      @RequestParam("token")
+      @NotEmptyNull String token,
+      @RequestParam("uid")
+      @Minimum long uid
+   ) {
+      oneTimeTokenService.validateTokenRequest(
+         new TokenIdResetPasswordRequest(
+            token,
+            uid
+         )
+      );
+      return ResponseEntity.status(SC_FOUND)
+         .location(URI.create("http://localhost:5173/password-reset"))
+         .build();
+   }
+
+   @PostMapping("/set-password")
+   public ResponseEntity<Void> setNewPassword(
+      @RequestBody
+      @Valid final PasswordResetDtoInput passwordResetDtoInput
+   ) {
+      oneTimeTokenService.resetPassword(passwordResetDtoInput);
+      return ResponseEntity.ok().build();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/auth/RecoveryAccountController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/auth/RecoveryAccountController.java
@@ -9,10 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth/accounts")

--- a/src/main/java/com/jame/dev/gymApp/entity/OneTimeTokenEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/entity/OneTimeTokenEntity.java
@@ -1,0 +1,65 @@
+package com.jame.dev.gymApp.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.Objects;
+
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Table(name = "one_time_tokens", indexes = {
+   @Index(name = "idx_one_time_tokens_user_unq", columnList = "user_id", unique = true)
+})
+public class OneTimeTokenEntity {
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.IDENTITY)
+   @Setter(AccessLevel.NONE)
+   private Long id;
+
+   @ManyToOne(
+      fetch = FetchType.LAZY,
+      optional = false)
+   @JoinColumn(
+      name = "user_id",
+      unique = true,
+      foreignKey = @ForeignKey(
+         name = "fk_one_time_token_user_id",
+         foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+      )
+   )
+   @NonNull
+   private UserEntity user;
+
+   @Column(name = "hash_token", nullable = false)
+   private String hashToken;
+
+   @Column(name = "created_at", nullable = false)
+   private Instant createdAt;
+
+   @Column(name = "expires_at", nullable = false)
+   private Instant expiresAt;
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      final OneTimeTokenEntity that = (OneTimeTokenEntity) o;
+      return Objects.equals(id, that.id);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hashCode(id);
+   }
+
+   @PrePersist
+   void setTimeStamps() {
+      this.createdAt = Instant.now();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/exception/ExpiredException.java
+++ b/src/main/java/com/jame/dev/gymApp/exception/ExpiredException.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.exception;
+
+public class ExpiredException extends RuntimeException {
+   public ExpiredException(String message) {
+      super(message);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/exception/OTTNotFoundException.java
+++ b/src/main/java/com/jame/dev/gymApp/exception/OTTNotFoundException.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.exception;
+
+public class OTTNotFoundException extends RuntimeException {
+   public OTTNotFoundException(String message) {
+      super(message);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/messages/service/HtmlTemplates.java
+++ b/src/main/java/com/jame/dev/gymApp/messages/service/HtmlTemplates.java
@@ -262,6 +262,65 @@ public final class HtmlTemplates {
            """
               .replace("{{recipient}}", subject)
               .replace("{{token}}", rawToken);
-   }
+    }
+
+    public static String magicUrlTemplate(final String magicUrl) {
+        return """
+               <!DOCTYPE html>
+               <html>
+               <head>
+                   <meta charset="UTF-8">
+                   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                   <title>Magic Link</title>
+               </head>
+               <body style="margin: 0; padding: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f4f7f9; color: #333;">
+                   <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                       <tr>
+                           <td align="center" style="padding: 40px 0;">
+                               <table border="0" cellpadding="0" cellspacing="0" width="600"
+                                      style="background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 4px 10px rgba(0,0,0,0.05);">
+                                   <tr>
+                                       <td align="center" style="background-color: #0891b2; padding: 30px 20px;">
+                                           <h1 style="color: #ffffff; margin: 0; font-size: 24px;">Magic Link</h1>
+                                       </td>
+                                   </tr>
+                                   <tr>
+                                       <td style="padding: 40px 30px;">
+                                           <p style="font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
+                                               Hello! Click the button below to complete your requested action. No additional codes are required.
+                                           </p>
+                                           <p style="font-size: 14px; color: #64748b; line-height: 1.6; margin-bottom: 30px;">
+                                               This link is valid for the next <strong>10 minutes</strong>. If you didn't request this, please ignore this email and your account will remain secure.
+                                           </p>
+                                           <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                               <tr>
+                                                   <td align="center">
+                                                       <a href="{{url}}"
+                                                          style="background-color: #0891b2; color: #ffffff; padding: 14px 30px; text-decoration: none; border-radius: 5px; font-weight: bold; display: inline-block;">
+                                                           Click to Proceed
+                                                       </a>
+                                                   </td>
+                                               </tr>
+                                           </table>
+                                           <p style="font-size: 12px; color: #94a3b8; margin-top: 20px; text-align: center;">
+                                               If the button doesn't work, copy and paste this URL into your browser: <br>
+                                               <span style="color: #0891b2; word-break: break-all;">{{url}}</span>
+                                           </p>
+                                       </td>
+                                   </tr>
+                                   <tr>
+                                       <td align="center" style="padding: 20px; background-color: #f1f5f9; color: #94a3b8; font-size: 12px;">
+                                           <p style="margin: 0;">This is an automated message, please don't reply to this email.</p>
+                                           <p style="margin: 5px 0 0;">&copy; 2024 GymApp - All rights reserved.</p>
+                                       </td>
+                                   </tr>
+                               </table>
+                           </td>
+                       </tr>
+                   </table>
+               </body>
+               </html>
+               """.replace("{{url}}", magicUrl);
+    }
 
 }

--- a/src/main/java/com/jame/dev/gymApp/model/dto/auth/TokenIdResetPasswordRequest.java
+++ b/src/main/java/com/jame/dev/gymApp/model/dto/auth/TokenIdResetPasswordRequest.java
@@ -1,0 +1,6 @@
+package com.jame.dev.gymApp.model.dto.auth;
+
+public record TokenIdResetPasswordRequest(
+   String rawToken, long uid
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/model/dto/in/PasswordResetDtoInput.java
+++ b/src/main/java/com/jame/dev/gymApp/model/dto/in/PasswordResetDtoInput.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.model.dto.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.aspects.annotations.constraints.EmailValid;
+import com.jame.dev.gymApp.aspects.annotations.constraints.NotEmptyNull;
+
+public record PasswordResetDtoInput(
+   @JsonProperty("email") @EmailValid String email,
+   @JsonProperty("newPassword") @NotEmptyNull String newPassword
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/model/listeners/PasswordResetEvent.java
+++ b/src/main/java/com/jame/dev/gymApp/model/listeners/PasswordResetEvent.java
@@ -1,0 +1,6 @@
+package com.jame.dev.gymApp.model.listeners;
+
+public record PasswordResetEvent(
+   String email, String rawToken
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/observers/PasswordResetEventListener.java
+++ b/src/main/java/com/jame/dev/gymApp/observers/PasswordResetEventListener.java
@@ -1,0 +1,45 @@
+package com.jame.dev.gymApp.observers;
+
+import com.jame.dev.gymApp.exception.UserNotFoundException;
+import com.jame.dev.gymApp.messages.service.EmailService;
+import com.jame.dev.gymApp.messages.service.HtmlTemplates;
+import com.jame.dev.gymApp.model.listeners.PasswordResetEvent;
+import com.jame.dev.gymApp.model.messages.EmailDetails;
+import com.jame.dev.gymApp.repository.UserRepository;
+import com.jame.dev.gymApp.service.in.OneTimeTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordResetEventListener {
+
+   private final OneTimeTokenService oneTimeTokenService;
+   private final UserRepository userRepository;
+   private final EmailService emailService;
+   private final static String MAGIC_URL = "http://localhost:8080/auth/passwords/reset?token={{token}}&&uid={{uid}}";
+
+   @Transactional
+   @EventListener(PasswordResetEvent.class)
+   public void savePasswordRequest(PasswordResetEvent passwordResetEvent) {
+      final String email = passwordResetEvent.email();
+      final String token = passwordResetEvent.rawToken();
+      final var userEntity = userRepository.findByEmail(email)
+         .orElseThrow(() -> new UserNotFoundException("User not found."));
+      oneTimeTokenService.saveToken(token, userEntity);
+
+
+      final EmailDetails emailDetails = new EmailDetails(
+         email,
+         HtmlTemplates.magicUrlTemplate(
+            MAGIC_URL
+               .replace("{{token}}", token)
+               .replace("{{uid}}", userEntity.getId().toString())),
+         "Password Reset"
+      );
+
+      emailService.sendSimpleEmail(emailDetails);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/repository/OneTimeTokenRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/repository/OneTimeTokenRepository.java
@@ -1,0 +1,16 @@
+package com.jame.dev.gymApp.repository;
+
+import com.jame.dev.gymApp.entity.OneTimeTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+import java.util.Optional;
+
+public interface OneTimeTokenRepository extends JpaRepository<OneTimeTokenEntity, Long> {
+   @Modifying
+   void deleteByUserId(final long userId);
+
+   boolean existsByUserId(final long userId);
+
+   Optional<OneTimeTokenEntity> findByUserId(final long userId);
+}

--- a/src/main/java/com/jame/dev/gymApp/service/in/OneTimeTokenService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/in/OneTimeTokenService.java
@@ -1,0 +1,14 @@
+package com.jame.dev.gymApp.service.in;
+
+import com.jame.dev.gymApp.entity.UserEntity;
+import com.jame.dev.gymApp.model.dto.auth.TokenIdResetPasswordRequest;
+import com.jame.dev.gymApp.model.dto.in.PasswordResetDtoInput;
+
+public interface OneTimeTokenService {
+   void saveToken(final String rawToken, final UserEntity user);
+
+   void validateTokenRequest(
+      final TokenIdResetPasswordRequest tokenIdResetPasswordRequest);
+
+   void resetPassword(final PasswordResetDtoInput passwordResetDtoInput);
+}

--- a/src/main/java/com/jame/dev/gymApp/service/in/TokenDBHasherService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/in/TokenDBHasherService.java
@@ -1,0 +1,6 @@
+package com.jame.dev.gymApp.service.in;
+
+public interface TokenDBHasherService {
+   String hashToken(final String rawToken);
+   boolean tokenMatches(final String rawToken, final String hashedToken);
+}

--- a/src/main/java/com/jame/dev/gymApp/service/in/TokenGeneratorService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/in/TokenGeneratorService.java
@@ -2,4 +2,5 @@ package com.jame.dev.gymApp.service.in;
 
 public interface TokenGeneratorService {
    String generateToken();
+   String generateTokenOneTimeToken();
 }

--- a/src/main/java/com/jame/dev/gymApp/service/out/OneTimeTokenServiceImp.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/OneTimeTokenServiceImp.java
@@ -1,0 +1,80 @@
+package com.jame.dev.gymApp.service.out;
+
+import com.jame.dev.gymApp.entity.OneTimeTokenEntity;
+import com.jame.dev.gymApp.entity.UserEntity;
+import com.jame.dev.gymApp.exception.ExpiredException;
+import com.jame.dev.gymApp.exception.MissMatchException;
+import com.jame.dev.gymApp.exception.OTTNotFoundException;
+import com.jame.dev.gymApp.exception.UserEntityNotFoundException;
+import com.jame.dev.gymApp.model.dto.auth.TokenIdResetPasswordRequest;
+import com.jame.dev.gymApp.model.dto.in.PasswordResetDtoInput;
+import com.jame.dev.gymApp.repository.OneTimeTokenRepository;
+import com.jame.dev.gymApp.repository.UserRepository;
+import com.jame.dev.gymApp.service.in.OneTimeTokenService;
+import com.jame.dev.gymApp.service.in.TokenDBHasherService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class OneTimeTokenServiceImp implements OneTimeTokenService {
+
+   private final OneTimeTokenRepository repository;
+   private final UserRepository userRepository;
+   private final TokenDBHasherService hasherService;
+   private final PasswordEncoder passwordEncoder;
+
+   @Override
+   @Transactional
+   public void saveToken(String rawToken, UserEntity user) {
+      repository.deleteByUserId(user.getId());
+      final OneTimeTokenEntity oneTimeTokenEntity = new OneTimeTokenEntity();
+      oneTimeTokenEntity.setUser(user);
+      oneTimeTokenEntity.setHashToken(hasherService.hashToken(rawToken));
+      oneTimeTokenEntity.setExpiresAt(Instant.now().plusSeconds(600L));
+      repository.saveAndFlush(oneTimeTokenEntity);
+   }
+
+   @Override
+   public void validateTokenRequest(
+      final TokenIdResetPasswordRequest tokenIdResetPasswordRequest) {
+      final OneTimeTokenEntity resetTokenEntity = repository
+         .findByUserId(tokenIdResetPasswordRequest.uid())
+         .orElseThrow(() -> new OTTNotFoundException("No record founded"));
+
+      boolean isExpired = Instant.now()
+         .isAfter(resetTokenEntity.getExpiresAt());
+      if (isExpired) {
+         throw new ExpiredException("Token is expired");
+      }
+
+      boolean hashMatches = hasherService.tokenMatches(
+         tokenIdResetPasswordRequest.rawToken(),
+         resetTokenEntity.getHashToken()
+      );
+
+      if (!hashMatches) {
+         throw new MissMatchException("Tokens doesn't match");
+      }
+   }
+
+   @Override
+   @Transactional
+   public void resetPassword(PasswordResetDtoInput passwordResetDtoInput) {
+      final UserEntity user = userRepository.findByEmail(passwordResetDtoInput.email())
+         .orElseThrow(() -> new UserEntityNotFoundException("User not found."));
+
+      if (!repository.existsByUserId(user.getId())) {
+         throw new OTTNotFoundException("Reset password is not allowed.");
+      }
+
+      final String newPasswordHashed = passwordEncoder.encode(passwordResetDtoInput.newPassword());
+      user.setPassword(newPasswordHashed);
+
+      repository.deleteByUserId(user.getId());
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/service/out/SHA256TokenDBHasherService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/SHA256TokenDBHasherService.java
@@ -1,0 +1,45 @@
+package com.jame.dev.gymApp.service.out;
+
+import com.jame.dev.gymApp.service.in.TokenDBHasherService;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Service
+public class SHA256TokenDBHasherService implements TokenDBHasherService {
+   private static final String ALGORITHM = "SHA-256";
+
+   @Override
+   public String hashToken(String rawToken) {
+      try {
+         final MessageDigest digest = MessageDigest.getInstance(ALGORITHM);
+         final byte[] hashBytes = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+         return bytesToHex(hashBytes);
+      } catch (NoSuchAlgorithmException e) {
+         throw new IllegalStateException(ALGORITHM + " algorithm not available", e);
+      }
+   }
+
+   @Override
+   public boolean tokenMatches(String rawToken, String hashedToken) {
+      final String computedHash = this.hashToken(rawToken);
+      return MessageDigest.isEqual(
+         computedHash.getBytes(StandardCharsets.UTF_8),
+         hashedToken.getBytes(StandardCharsets.UTF_8)
+      );
+   }
+
+   private static String bytesToHex(byte[] bytes) {
+      final StringBuilder hexString = new StringBuilder(bytes.length * 2);
+      for (byte b : bytes) {
+         final String hex = Integer.toHexString(0xff & b);
+         if (hex.length() == 1) {
+            hexString.append('0');
+         }
+         hexString.append(hex);
+      }
+      return hexString.toString();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/service/out/TokenGeneratorImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/TokenGeneratorImplementation.java
@@ -4,6 +4,7 @@ import com.jame.dev.gymApp.service.in.TokenGeneratorService;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.Base64;
 
 @Service
 public class TokenGeneratorImplementation implements TokenGeneratorService {
@@ -11,13 +12,19 @@ public class TokenGeneratorImplementation implements TokenGeneratorService {
 
    @Override
    public String generateToken() {
-      final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-      final StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < 6; i++) {
-         int index = random.nextInt(CHARACTERS.length());
-         char character = CHARACTERS.charAt(index);
-         sb.append(character);
-      }
-      return sb.toString();
+      byte[] bytes = new byte[6];
+      random.nextBytes(bytes);
+      return Base64.getUrlEncoder()
+         .withoutPadding()
+         .encodeToString(bytes);
+   }
+
+   @Override
+   public String generateTokenOneTimeToken() {
+      byte[] bytes = new byte[32];
+      random.nextBytes(bytes);
+      return Base64.getUrlEncoder()
+         .withoutPadding()
+         .encodeToString(bytes);
    }
 }

--- a/src/test/java/com/jame/dev/gymApp/service/OneTimeTokenServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/OneTimeTokenServiceTest.java
@@ -1,0 +1,208 @@
+package com.jame.dev.gymApp.service;
+
+import com.jame.dev.gymApp.entity.OneTimeTokenEntity;
+import com.jame.dev.gymApp.entity.UserEntity;
+import com.jame.dev.gymApp.exception.ExpiredException;
+import com.jame.dev.gymApp.exception.MissMatchException;
+import com.jame.dev.gymApp.exception.OTTNotFoundException;
+import com.jame.dev.gymApp.exception.UserEntityNotFoundException;
+import com.jame.dev.gymApp.model.dto.auth.TokenIdResetPasswordRequest;
+import com.jame.dev.gymApp.model.dto.in.PasswordResetDtoInput;
+import com.jame.dev.gymApp.repository.OneTimeTokenRepository;
+import com.jame.dev.gymApp.repository.UserRepository;
+import com.jame.dev.gymApp.service.in.TokenDBHasherService;
+import com.jame.dev.gymApp.service.out.OneTimeTokenServiceImp;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.ArgumentCaptor;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class OneTimeTokenServiceTest {
+
+    @Mock
+    private OneTimeTokenRepository repository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TokenDBHasherService hasherService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private OneTimeTokenServiceImp underTest;
+
+    @Nested
+    @DisplayName("Tests for saveToken method")
+    class SaveTokenTest {
+
+        @Test
+        @DisplayName("Should save token successfully with valid inputs")
+        void shouldSaveTokenSuccessfully() {
+            String rawToken = "validRawToken";
+            UserEntity user = mock(UserEntity.class);
+            when(user.getId()).thenReturn(1L);
+            String hashedToken = "hashedToken";
+
+            given(hasherService.hashToken(rawToken)).willReturn(hashedToken);
+
+            underTest.saveToken(rawToken, user);
+
+            verify(repository).deleteByUserId(eq(1L));
+            verify(hasherService).hashToken(eq(rawToken));
+
+            ArgumentCaptor<OneTimeTokenEntity> captor = ArgumentCaptor.forClass(OneTimeTokenEntity.class);
+            verify(repository).saveAndFlush(captor.capture());
+
+            OneTimeTokenEntity saved = captor.getValue();
+            assertEquals(user, saved.getUser());
+            assertEquals(hashedToken, saved.getHashToken());
+            assertTrue(saved.getExpiresAt().isAfter(Instant.now()));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for validateTokenRequest method")
+    class ValidateTokenRequestTest {
+
+        @Test
+        @DisplayName("Should pass validation with valid non-expired matching token")
+        void shouldValidateSuccessfully() {
+            long userId = 1L;
+            String rawToken = "validRawToken";
+            String hashedToken = "hashedToken";
+            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest(rawToken, userId);
+
+            OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+            when(tokenEntity.getHashToken()).thenReturn(hashedToken);
+            when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().plusSeconds(300L));
+
+            given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
+            given(hasherService.tokenMatches(rawToken, hashedToken)).willReturn(true);
+
+            assertDoesNotThrow(() -> underTest.validateTokenRequest(request));
+
+            verify(repository).findByUserId(eq(userId));
+            verify(hasherService).tokenMatches(eq(rawToken), eq(hashedToken));
+        }
+
+        @Test
+        @DisplayName("Should throw OTTNotFoundException when token not found")
+        void shouldThrowNotFoundWhenTokenMissing() {
+            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest("rawToken", 1L);
+            willThrow(OTTNotFoundException.class)
+               .given(repository).findByUserId(1L);
+
+            assertThrowsExactly(OTTNotFoundException.class, () -> underTest.validateTokenRequest(request));
+            verify(repository).findByUserId(eq(1L));
+        }
+
+        @Test
+        @DisplayName("Should throw ExpiredException when token is expired")
+        void shouldThrowExpiredWhenTokenExpired() {
+            Long userId = 1L;
+            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest("rawToken", userId);
+
+            OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+            when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().minusSeconds(10L));
+
+            given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
+
+            assertThrowsExactly(ExpiredException.class, () -> underTest.validateTokenRequest(request));
+            verify(repository).findByUserId(eq(userId));
+            verify(hasherService, never()).tokenMatches(anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("Should throw MissMatchException when token hash mismatch")
+        void shouldThrowMismatchWhenHashInvalid() {
+            Long userId = 1L;
+            String rawToken = "rawToken";
+            String hashedToken = "hashedToken";
+            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest(rawToken, userId);
+
+            OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+            when(tokenEntity.getHashToken()).thenReturn(hashedToken);
+            when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().plusSeconds(300L));
+
+            given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
+            given(hasherService.tokenMatches(rawToken, hashedToken)).willReturn(false);
+
+            assertThrowsExactly(MissMatchException.class, () -> underTest.validateTokenRequest(request));
+            verify(repository).findByUserId(eq(userId));
+            verify(hasherService).tokenMatches(eq(rawToken), eq(hashedToken));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tests for resetPassword method")
+    class ResetPasswordTest {
+
+        @Test
+        @DisplayName("Should reset password successfully with valid inputs")
+        void shouldResetPasswordSuccessfully() {
+            String email = "test@example.com";
+            String newPassword = "newPassword123";
+            String hashedNewPassword = "hashedNewPassword";
+            PasswordResetDtoInput request = new PasswordResetDtoInput(email, newPassword);
+
+            UserEntity user = mock(UserEntity.class);
+            when(user.getId()).thenReturn(1L);
+
+            given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+            given(repository.existsByUserId(1L)).willReturn(true);
+            given(passwordEncoder.encode(newPassword)).willReturn(hashedNewPassword);
+
+            underTest.resetPassword(request);
+
+            verify(userRepository).findByEmail(eq(email));
+            verify(repository).existsByUserId(eq(1L));
+            verify(passwordEncoder).encode(eq(newPassword));
+            verify(user).setPassword(hashedNewPassword);
+            verify(repository).deleteByUserId(eq(1L));
+        }
+
+        @Test
+        @DisplayName("Should throw UserEntityNotFoundException when email not found")
+        void shouldThrowUserNotFoundWhenEmailInvalid() {
+            PasswordResetDtoInput request = new PasswordResetDtoInput("nonexistent@example.com", "newPass");
+            willThrow(UserEntityNotFoundException.class)
+               .given(userRepository)
+               .findByEmail(request.email());
+
+            assertThrowsExactly(UserEntityNotFoundException.class, () -> underTest.resetPassword(request));
+            verify(userRepository).findByEmail(eq(request.email()));
+        }
+
+        @Test
+        @DisplayName("Should throw OTTNotFoundException when no token exists for user")
+        void shouldThrowOttNotFoundWhenNoToken() {
+            String email = "test@example.com";
+            PasswordResetDtoInput request = new PasswordResetDtoInput(email, "newPass");
+            UserEntity user = mock(UserEntity.class);
+            when(user.getId()).thenReturn(1L);
+
+            given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+            given(repository.existsByUserId(1L)).willReturn(false);
+
+            assertThrowsExactly(OTTNotFoundException.class, () -> underTest.resetPassword(request));
+            verify(userRepository).findByEmail(eq(email));
+            verify(repository).existsByUserId(eq(1L));
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request: features/password-recovery

## Description
This PR introduces a feature that allows the password recovering through a hash temporal token validations and and also set up various test cases of the new service feature, the TokenGenerationService got refactored and improved. Also a TokenDBHasherService was introduced in this PR.   

---

## Main Changes
- ### /entity
   - `OneTimeTokenEntity` created to handle DB  schema and data operations for one_time_tokens table.
- ### /repository 
   - `OnTimeTokenRepository` repository that allows interactions with the DB for this particular feature.
- ### aspects
   - `@PublishPasswordResetRequest` annotation to link with an aspect.
   - `PublisherPasswordRequestAspect` Implementation Aspect class that works as a publisher of `PasswordResetEvent`'s.
- ### observers 
   - `PasswordResetEventListener` class that receives and handles `PasswordResetEvent`'s, it finds an existing user and then if it finds him save the `OneTimeTokenEntity`.
- ### service
   - `OnetimeTokenService/OneTimeTokenServiceImp` classes created that defines a contract with: 
      1. `saveToken(String rawToken)` -> saves a `OneTimeTokenEntity`
      2. `validateTokenRequest(TokenIdResetPasswordRequest tokenResetPasswordRequest)` -> validates the incoming request values and fetch associations in the DB to perform business validations and throws exception if some validation fails..
      3. `resetPassword(PasswordResetDtoInput passwordResetDtoInput)` -> set the new password after checks if there's a record in the one_time_tokens table and at the end it deletes the associated record.
   - `TokenGenerationService` now defines `generateOneTimeToken` that generates a large token.
   - TokenDBHasherService defines hashToken that hash a token and tokenMatches that validates if the tokens are the same one, implementation is SHA256TokenDBHasherService, so the hash is algorithm is SHA-256.

   - `PasswordResetController` controller done to be the handler mapping for `/auth/passwords` requests and manage the resources provided: `"/request-reset"`, **"/reset"**, `"/set-password"`.
---

## Minimal Changes
- ### /config
   - `WebSecurityConfig` removes unnecessarily requestMatchers for `"/auth"` endpoints.
- ### /model
   - Auth dto created named `TokenIdResetPasswordRequest`
   - Input dto created named `PasswordResetDtoInput`
   - Listener dto created named `PasswordResetEvent`  
---

## Notes 
- Test class for OneTimeTokenService created and named: OneTimeTokenServiceTest.
---