### PR TITLE
fix(OneTimeTokenService): Vulnerability that a user makes the request…

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/controller/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/advice/GlobalExceptionHandler.java
@@ -349,4 +349,31 @@ public class GlobalExceptionHandler {
               .buildResponse(new InputError(
                       ex, request, HttpStatus.LOCKED, ErrorCodes.ACCESS_DENIED));
    }
+
+   @ExceptionHandler(OTTNotFoundException.class)
+   public ResponseEntity<ApiErrorResponse> handleOTTNotFoundException(
+      OTTNotFoundException ex, HttpServletRequest request
+   ) {
+      return responseFactory
+         .buildResponse(new InputError(
+            ex, request, HttpStatus.NOT_FOUND, ErrorCodes.NOT_FOUND));
+   }
+
+   @ExceptionHandler(UserEntityNotFoundException.class)
+   public ResponseEntity<ApiErrorResponse> handleUserEntityNotFoundException(
+      UserEntityNotFoundException ex, HttpServletRequest request
+   ) {
+      return responseFactory
+         .buildResponse(new InputError(
+            ex, request, HttpStatus.NOT_FOUND, ErrorCodes.NOT_FOUND));
+   }
+
+   @ExceptionHandler(UnverifiedOTTException.class)
+   public ResponseEntity<ApiErrorResponse> handleUnverifiedOTTException(
+      UnverifiedOTTException ex, HttpServletRequest request
+   ) {
+      return responseFactory
+         .buildResponse(new InputError(
+            ex, request, HttpStatus.UNAUTHORIZED, ErrorCodes.ACCESS_DENIED));
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/auth/PasswordResetController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/auth/PasswordResetController.java
@@ -9,6 +9,7 @@ import com.jame.dev.gymApp.model.dto.in.RecoveryRequest;
 import com.jame.dev.gymApp.service.in.OneTimeTokenService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +23,9 @@ import static jakarta.servlet.http.HttpServletResponse.SC_FOUND;
 @RequiredArgsConstructor
 @Validated
 public class PasswordResetController {
+   @Value("${app.auth.redirect.url.password-reset:}")
+   private String REDIRECT_URL;
+
    private final OneTimeTokenService oneTimeTokenService;
 
    @PostMapping("/request-reset")
@@ -47,7 +51,7 @@ public class PasswordResetController {
          )
       );
       return ResponseEntity.status(SC_FOUND)
-         .location(URI.create("http://localhost:5173/password-reset"))
+         .location(URI.create(REDIRECT_URL))
          .build();
    }
 

--- a/src/main/java/com/jame/dev/gymApp/entity/OneTimeTokenEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/entity/OneTimeTokenEntity.java
@@ -39,6 +39,9 @@ public class OneTimeTokenEntity {
    @Column(name = "hash_token", nullable = false)
    private String hashToken;
 
+   @Column(name = "token_verified", nullable = false)
+   private boolean tokenVerified = false;
+
    @Column(name = "created_at", nullable = false)
    private Instant createdAt;
 

--- a/src/main/java/com/jame/dev/gymApp/exception/UnverifiedOTTException.java
+++ b/src/main/java/com/jame/dev/gymApp/exception/UnverifiedOTTException.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.exception;
+
+public class UnverifiedOTTException extends RuntimeException {
+   public UnverifiedOTTException(String message) {
+      super(message);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/service/out/OneTimeTokenServiceImp.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/OneTimeTokenServiceImp.java
@@ -2,10 +2,7 @@ package com.jame.dev.gymApp.service.out;
 
 import com.jame.dev.gymApp.entity.OneTimeTokenEntity;
 import com.jame.dev.gymApp.entity.UserEntity;
-import com.jame.dev.gymApp.exception.ExpiredException;
-import com.jame.dev.gymApp.exception.MissMatchException;
-import com.jame.dev.gymApp.exception.OTTNotFoundException;
-import com.jame.dev.gymApp.exception.UserEntityNotFoundException;
+import com.jame.dev.gymApp.exception.*;
 import com.jame.dev.gymApp.model.dto.auth.TokenIdResetPasswordRequest;
 import com.jame.dev.gymApp.model.dto.in.PasswordResetDtoInput;
 import com.jame.dev.gymApp.repository.OneTimeTokenRepository;
@@ -40,6 +37,7 @@ public class OneTimeTokenServiceImp implements OneTimeTokenService {
    }
 
    @Override
+   @Transactional
    public void validateTokenRequest(
       final TokenIdResetPasswordRequest tokenIdResetPasswordRequest) {
       final OneTimeTokenEntity resetTokenEntity = repository
@@ -60,6 +58,8 @@ public class OneTimeTokenServiceImp implements OneTimeTokenService {
       if (!hashMatches) {
          throw new MissMatchException("Tokens doesn't match");
       }
+
+      resetTokenEntity.setTokenVerified(Boolean.TRUE);
    }
 
    @Override
@@ -68,8 +68,11 @@ public class OneTimeTokenServiceImp implements OneTimeTokenService {
       final UserEntity user = userRepository.findByEmail(passwordResetDtoInput.email())
          .orElseThrow(() -> new UserEntityNotFoundException("User not found."));
 
-      if (!repository.existsByUserId(user.getId())) {
-         throw new OTTNotFoundException("Reset password is not allowed.");
+      final var ott = repository.findByUserId(user.getId())
+         .orElseThrow(() -> new OTTNotFoundException("Reset password is not allowed."));
+
+      if(!ott.isTokenVerified()) {
+         throw new UnverifiedOTTException("Token unchecked.");
       }
 
       final String newPasswordHashed = passwordEncoder.encode(passwordResetDtoInput.newPassword());

--- a/src/main/java/com/jame/dev/gymApp/service/out/TokenGeneratorImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/TokenGeneratorImplementation.java
@@ -9,14 +9,17 @@ import java.util.Base64;
 @Service
 public class TokenGeneratorImplementation implements TokenGeneratorService {
    private final SecureRandom random = new SecureRandom();
+   private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTWVXYZ0123456789";
 
    @Override
    public String generateToken() {
-      byte[] bytes = new byte[6];
-      random.nextBytes(bytes);
-      return Base64.getUrlEncoder()
-         .withoutPadding()
-         .encodeToString(bytes);
+      final StringBuilder sb = new StringBuilder(6);
+      final int capacity = sb.capacity();
+      for (int i = 0; i < capacity; i++) {
+         final char ch = CHARACTERS.charAt(random.nextInt(CHARACTERS.length()));
+         sb.append(ch);
+      }
+      return sb.toString();
    }
 
    @Override

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,6 +4,7 @@ spring.config.import=optional:file:.env.dev[.properties]
 #app
 app.cors.allowed-origins=http://localhost:5173
 app.auth.redirect-url=http://localhost:5173/home
+app.auth.redirect.url.password-reset=http://localhost:5173/password-reset
 
 # JPA DEV
 spring.jpa.hibernate.ddl-auto=create

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,6 +4,7 @@ spring.jpa.show-sql=false
 
 app.cors.allowed-origins=${APP_CORS_ALLOWED_ORIGINS}
 app.auth.redirect-url=${APP_AUTH_REDIRECT_URL}
+app.auth.redirect.url.password-reset=${APP_AUTH_REDIRECT_URL_RESET}
 
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=${DATASOURCE_URL}

--- a/src/test/java/com/jame/dev/gymApp/service/OneTimeTokenServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/OneTimeTokenServiceTest.java
@@ -2,207 +2,223 @@ package com.jame.dev.gymApp.service;
 
 import com.jame.dev.gymApp.entity.OneTimeTokenEntity;
 import com.jame.dev.gymApp.entity.UserEntity;
-import com.jame.dev.gymApp.exception.ExpiredException;
-import com.jame.dev.gymApp.exception.MissMatchException;
-import com.jame.dev.gymApp.exception.OTTNotFoundException;
-import com.jame.dev.gymApp.exception.UserEntityNotFoundException;
+import com.jame.dev.gymApp.exception.*;
 import com.jame.dev.gymApp.model.dto.auth.TokenIdResetPasswordRequest;
 import com.jame.dev.gymApp.model.dto.in.PasswordResetDtoInput;
 import com.jame.dev.gymApp.repository.OneTimeTokenRepository;
 import com.jame.dev.gymApp.repository.UserRepository;
 import com.jame.dev.gymApp.service.in.TokenDBHasherService;
 import com.jame.dev.gymApp.service.out.OneTimeTokenServiceImp;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.ArgumentCaptor;
-
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.Instant;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class OneTimeTokenServiceTest {
 
-    @Mock
-    private OneTimeTokenRepository repository;
-    @Mock
-    private UserRepository userRepository;
-    @Mock
-    private TokenDBHasherService hasherService;
-    @Mock
-    private PasswordEncoder passwordEncoder;
+   @Mock
+   private OneTimeTokenRepository repository;
+   @Mock
+   private UserRepository userRepository;
+   @Mock
+   private TokenDBHasherService hasherService;
+   @Mock
+   private PasswordEncoder passwordEncoder;
 
-    @InjectMocks
-    private OneTimeTokenServiceImp underTest;
+   @InjectMocks
+   private OneTimeTokenServiceImp underTest;
 
-    @Nested
-    @DisplayName("Tests for saveToken method")
-    class SaveTokenTest {
+   @Nested
+   @DisplayName("Tests for saveToken method")
+   class SaveTokenTest {
 
-        @Test
-        @DisplayName("Should save token successfully with valid inputs")
-        void shouldSaveTokenSuccessfully() {
-            String rawToken = "validRawToken";
-            UserEntity user = mock(UserEntity.class);
-            when(user.getId()).thenReturn(1L);
-            String hashedToken = "hashedToken";
+      @Test
+      @DisplayName("Should save token successfully with valid inputs")
+      void shouldSaveTokenSuccessfully() {
+         String rawToken = "validRawToken";
+         UserEntity user = mock(UserEntity.class);
+         when(user.getId()).thenReturn(1L);
+         String hashedToken = "hashedToken";
 
-            given(hasherService.hashToken(rawToken)).willReturn(hashedToken);
+         given(hasherService.hashToken(rawToken)).willReturn(hashedToken);
 
-            underTest.saveToken(rawToken, user);
+         underTest.saveToken(rawToken, user);
 
-            verify(repository).deleteByUserId(eq(1L));
-            verify(hasherService).hashToken(eq(rawToken));
+         verify(repository).deleteByUserId(eq(1L));
+         verify(hasherService).hashToken(eq(rawToken));
 
-            ArgumentCaptor<OneTimeTokenEntity> captor = ArgumentCaptor.forClass(OneTimeTokenEntity.class);
-            verify(repository).saveAndFlush(captor.capture());
+         ArgumentCaptor<OneTimeTokenEntity> captor = ArgumentCaptor.forClass(OneTimeTokenEntity.class);
+         verify(repository).saveAndFlush(captor.capture());
 
-            OneTimeTokenEntity saved = captor.getValue();
-            assertEquals(user, saved.getUser());
-            assertEquals(hashedToken, saved.getHashToken());
-            assertTrue(saved.getExpiresAt().isAfter(Instant.now()));
-        }
-    }
+         OneTimeTokenEntity saved = captor.getValue();
+         assertEquals(user, saved.getUser());
+         assertEquals(hashedToken, saved.getHashToken());
+         assertTrue(saved.getExpiresAt().isAfter(Instant.now()));
+      }
+   }
 
-    @Nested
-    @DisplayName("Tests for validateTokenRequest method")
-    class ValidateTokenRequestTest {
+   @Nested
+   @DisplayName("Tests for validateTokenRequest method")
+   class ValidateTokenRequestTest {
 
-        @Test
-        @DisplayName("Should pass validation with valid non-expired matching token")
-        void shouldValidateSuccessfully() {
-            long userId = 1L;
-            String rawToken = "validRawToken";
-            String hashedToken = "hashedToken";
-            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest(rawToken, userId);
+      @Test
+      @DisplayName("Should pass validation with valid non-expired matching token")
+      void shouldValidateSuccessfully() {
+         long userId = 1L;
+         String rawToken = "validRawToken";
+         String hashedToken = "hashedToken";
+         TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest(rawToken, userId);
 
-            OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
-            when(tokenEntity.getHashToken()).thenReturn(hashedToken);
-            when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().plusSeconds(300L));
+         OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+         when(tokenEntity.getHashToken()).thenReturn(hashedToken);
+         when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().plusSeconds(300L));
+         doNothing().when(tokenEntity).setTokenVerified(true);
 
-            given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
-            given(hasherService.tokenMatches(rawToken, hashedToken)).willReturn(true);
+         given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
+         given(hasherService.tokenMatches(rawToken, hashedToken)).willReturn(true);
 
-            assertDoesNotThrow(() -> underTest.validateTokenRequest(request));
+         assertDoesNotThrow(() -> underTest.validateTokenRequest(request));
 
-            verify(repository).findByUserId(eq(userId));
-            verify(hasherService).tokenMatches(eq(rawToken), eq(hashedToken));
-        }
+         verify(repository).findByUserId(eq(userId));
+         verify(hasherService).tokenMatches(eq(rawToken), eq(hashedToken));
+      }
 
-        @Test
-        @DisplayName("Should throw OTTNotFoundException when token not found")
-        void shouldThrowNotFoundWhenTokenMissing() {
-            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest("rawToken", 1L);
-            willThrow(OTTNotFoundException.class)
-               .given(repository).findByUserId(1L);
+      @Test
+      @DisplayName("Should throw OTTNotFoundException when token not found")
+      void shouldThrowNotFoundWhenTokenMissing() {
+         TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest("rawToken", 1L);
+         willThrow(OTTNotFoundException.class)
+            .given(repository).findByUserId(1L);
 
-            assertThrowsExactly(OTTNotFoundException.class, () -> underTest.validateTokenRequest(request));
-            verify(repository).findByUserId(eq(1L));
-        }
+         assertThrowsExactly(OTTNotFoundException.class, () -> underTest.validateTokenRequest(request));
+         verify(repository).findByUserId(eq(1L));
+      }
 
-        @Test
-        @DisplayName("Should throw ExpiredException when token is expired")
-        void shouldThrowExpiredWhenTokenExpired() {
-            Long userId = 1L;
-            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest("rawToken", userId);
+      @Test
+      @DisplayName("Should throw ExpiredException when token is expired")
+      void shouldThrowExpiredWhenTokenExpired() {
+         Long userId = 1L;
+         TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest("rawToken", userId);
 
-            OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
-            when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().minusSeconds(10L));
+         OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+         when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().minusSeconds(10L));
 
-            given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
+         given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
 
-            assertThrowsExactly(ExpiredException.class, () -> underTest.validateTokenRequest(request));
-            verify(repository).findByUserId(eq(userId));
-            verify(hasherService, never()).tokenMatches(anyString(), anyString());
-        }
+         assertThrowsExactly(ExpiredException.class, () -> underTest.validateTokenRequest(request));
+         verify(repository).findByUserId(eq(userId));
+         verify(hasherService, never()).tokenMatches(anyString(), anyString());
+      }
 
-        @Test
-        @DisplayName("Should throw MissMatchException when token hash mismatch")
-        void shouldThrowMismatchWhenHashInvalid() {
-            Long userId = 1L;
-            String rawToken = "rawToken";
-            String hashedToken = "hashedToken";
-            TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest(rawToken, userId);
+      @Test
+      @DisplayName("Should throw MissMatchException when token hash mismatch")
+      void shouldThrowMismatchWhenHashInvalid() {
+         Long userId = 1L;
+         String rawToken = "rawToken";
+         String hashedToken = "hashedToken";
+         TokenIdResetPasswordRequest request = new TokenIdResetPasswordRequest(rawToken, userId);
 
-            OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
-            when(tokenEntity.getHashToken()).thenReturn(hashedToken);
-            when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().plusSeconds(300L));
+         OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+         when(tokenEntity.getHashToken()).thenReturn(hashedToken);
+         when(tokenEntity.getExpiresAt()).thenReturn(Instant.now().plusSeconds(300L));
 
-            given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
-            given(hasherService.tokenMatches(rawToken, hashedToken)).willReturn(false);
+         given(repository.findByUserId(userId)).willReturn(Optional.of(tokenEntity));
+         given(hasherService.tokenMatches(rawToken, hashedToken)).willReturn(false);
 
-            assertThrowsExactly(MissMatchException.class, () -> underTest.validateTokenRequest(request));
-            verify(repository).findByUserId(eq(userId));
-            verify(hasherService).tokenMatches(eq(rawToken), eq(hashedToken));
-        }
-    }
+         assertThrowsExactly(MissMatchException.class, () -> underTest.validateTokenRequest(request));
+         verify(repository).findByUserId(eq(userId));
+         verify(hasherService).tokenMatches(eq(rawToken), eq(hashedToken));
+      }
+   }
 
-    @Nested
-    @DisplayName("Tests for resetPassword method")
-    class ResetPasswordTest {
+   @Nested
+   @DisplayName("Tests for resetPassword method")
+   class ResetPasswordTest {
 
-        @Test
-        @DisplayName("Should reset password successfully with valid inputs")
-        void shouldResetPasswordSuccessfully() {
-            String email = "test@example.com";
-            String newPassword = "newPassword123";
-            String hashedNewPassword = "hashedNewPassword";
-            PasswordResetDtoInput request = new PasswordResetDtoInput(email, newPassword);
+      @Test
+      @DisplayName("Should reset password successfully with valid inputs")
+      void shouldResetPasswordSuccessfully() {
+         String email = "test@example.com";
+         String newPassword = "newPassword123";
+         String hashedNewPassword = "hashedNewPassword";
+         PasswordResetDtoInput request = new PasswordResetDtoInput(email, newPassword);
 
-            UserEntity user = mock(UserEntity.class);
-            when(user.getId()).thenReturn(1L);
+         UserEntity user = mock(UserEntity.class);
+         OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+         when(user.getId()).thenReturn(1L);
+         when(tokenEntity.isTokenVerified()).thenReturn(true);
 
-            given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
-            given(repository.existsByUserId(1L)).willReturn(true);
-            given(passwordEncoder.encode(newPassword)).willReturn(hashedNewPassword);
+         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+         given(repository.findByUserId(1L)).willReturn(Optional.of(tokenEntity));
+         given(passwordEncoder.encode(newPassword)).willReturn(hashedNewPassword);
 
-            underTest.resetPassword(request);
+         underTest.resetPassword(request);
 
-            verify(userRepository).findByEmail(eq(email));
-            verify(repository).existsByUserId(eq(1L));
-            verify(passwordEncoder).encode(eq(newPassword));
-            verify(user).setPassword(hashedNewPassword);
-            verify(repository).deleteByUserId(eq(1L));
-        }
+         verify(userRepository).findByEmail(eq(email));
+         verify(repository).findByUserId(eq(1L));
+         verify(passwordEncoder).encode(eq(newPassword));
+         verify(repository).deleteByUserId(eq(1L));
+      }
 
-        @Test
-        @DisplayName("Should throw UserEntityNotFoundException when email not found")
-        void shouldThrowUserNotFoundWhenEmailInvalid() {
-            PasswordResetDtoInput request = new PasswordResetDtoInput("nonexistent@example.com", "newPass");
-            willThrow(UserEntityNotFoundException.class)
-               .given(userRepository)
-               .findByEmail(request.email());
+      @Test
+      @DisplayName("Should throw UserEntityNotFoundException when email not found")
+      void shouldThrowUserNotFoundWhenEmailInvalid() {
+         PasswordResetDtoInput request = new PasswordResetDtoInput("nonexistent@example.com", "newPass");
+         willThrow(UserEntityNotFoundException.class)
+            .given(userRepository)
+            .findByEmail(request.email());
 
-            assertThrowsExactly(UserEntityNotFoundException.class, () -> underTest.resetPassword(request));
-            verify(userRepository).findByEmail(eq(request.email()));
-        }
+         assertThrowsExactly(UserEntityNotFoundException.class, () -> underTest.resetPassword(request));
+         verify(userRepository).findByEmail(eq(request.email()));
+      }
 
-        @Test
-        @DisplayName("Should throw OTTNotFoundException when no token exists for user")
-        void shouldThrowOttNotFoundWhenNoToken() {
-            String email = "test@example.com";
-            PasswordResetDtoInput request = new PasswordResetDtoInput(email, "newPass");
-            UserEntity user = mock(UserEntity.class);
-            when(user.getId()).thenReturn(1L);
+      @Test
+      @DisplayName("Should throw OTTNotFoundException when no token exists for user")
+      void shouldThrowOttNotFoundWhenNoToken() {
+         String email = "test@example.com";
+         PasswordResetDtoInput request = new PasswordResetDtoInput(email, "newPass");
 
-            given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
-            given(repository.existsByUserId(1L)).willReturn(false);
+         willThrow(OTTNotFoundException.class).given(userRepository).findByEmail(email);
 
-            assertThrowsExactly(OTTNotFoundException.class, () -> underTest.resetPassword(request));
-            verify(userRepository).findByEmail(eq(email));
-            verify(repository).existsByUserId(eq(1L));
-        }
-    }
+         assertThrowsExactly(OTTNotFoundException.class, () -> underTest.resetPassword(request));
+         verify(userRepository).findByEmail(eq(email));
+      }
+
+      @Test
+      @DisplayName("Should Throw UnverifiedOTTException when token is not verified.")
+      void shouldThrowUnverifiedOTTExceptionWhenTokenUnverified() {
+         String email = "test@example.com";
+         PasswordResetDtoInput request = new PasswordResetDtoInput(email, "newPass");
+
+         UserEntity user = mock(UserEntity.class);
+         OneTimeTokenEntity tokenEntity = mock(OneTimeTokenEntity.class);
+
+         when(user.getId()).thenReturn(1L);
+         when(tokenEntity.isTokenVerified()).thenReturn(false);
+
+         given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+         given(repository.findByUserId(1L)).willReturn(Optional.of(tokenEntity));
+
+         assertThrowsExactly(UnverifiedOTTException.class, () -> underTest.resetPassword(request));
+
+         verify(userRepository).findByEmail(eq(email));
+         verify(repository).findByUserId(eq(1L));
+      }
+   }
 }


### PR DESCRIPTION
# Pull Request: fixes/password-recovery 

# Description
This PR fixes a security vulnerability in the password reset flow where users could bypass the token validation step by directly navigating to the frontend password reset form and submitting a new password without having a previously validated token.

To address this issue, a new verification mechanism was introduced in the `OneTimeTokenEntity` through the `tokenVerified` field. The password reset process now requires the token to be explicitly validated before allowing the password update operation.

Additionally, the PR improves exception handling, token generation behavior, configuration flexibility, and test coverage for the reset password workflow.

---

# Main Changes

- Added a new field `tokenVerified` in `OneTimeTokenEntity` to persist the validation state of a reset token.
- Updated `validateTokenRequest()` in `OneTimeTokenServiceImp` to:
  - Mark tokens as verified only after all validations pass successfully.
  - Execute within a transactional context to ensure entity state persistence.
- Updated `resetPassword()` logic to:
  - Retrieve the token entity instead of only checking its existence.
  - Prevent password reset if the token has not been verified.
  - Throw the new `UnverifiedOTTException` when the token validation step was skipped.
- Added `UnverifiedOTTException` and integrated it into the global exception handling flow.
- Added dedicated exception handlers for:
  - `OTTNotFoundException`
  - `UserEntityNotFoundException`
  - `UnverifiedOTTException`
- Replaced the hardcoded password reset redirect URL with configurable properties:
  - `app.auth.redirect.url.password-reset`
- Refactored token generation logic:
  - Replaced Base64 token generation with a custom alphanumeric token generator using `SecureRandom`.
- Expanded unit test coverage for:
  - Successful token verification flow.
  - Unverified token scenarios.
  - Updated password reset validation behavior.

---

# Minimal Changes

- Replaced wildcard exception imports with consolidated import usage.
- Added missing `@Transactional` annotation to ensure persistence consistency.
- Minor formatting and indentation adjustments in test files.
- Added `doNothing()` mock behavior for `setTokenVerified(true)` in unit tests.
- Added new application properties for password reset redirect URLs in both development and production environments.

---

# Notes

- A database migration may be required to add the `token_verified` column in environments where schema auto-generation is disabled.
- Consider invalidating/resetting `tokenVerified` after successful password updates to avoid token reuse edge cases.
- Future improvements could include:
- Adding expiration cleanup jobs for verified/expired tokens.
- Frontend flows should ensure the token validation endpoint is always called before rendering or enabling the password reset form.