### PR TITLE
API data filtering

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/aspects/annotations/constraints/SortPropertyValid.java
+++ b/src/main/java/com/jame/dev/gymApp/aspects/annotations/constraints/SortPropertyValid.java
@@ -1,0 +1,20 @@
+package com.jame.dev.gymApp.aspects.annotations.constraints;
+
+
+import com.jame.dev.gymApp.aspects.imp.constraints.SortPropertyValidConstraint;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = {SortPropertyValidConstraint.class})
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+public @interface SortPropertyValid {
+   String message() default "Sort property not allowed.";
+
+   Class<?>[] groups() default {};
+
+   Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/jame/dev/gymApp/aspects/imp/constraints/SortPropertyValidConstraint.java
+++ b/src/main/java/com/jame/dev/gymApp/aspects/imp/constraints/SortPropertyValidConstraint.java
@@ -1,0 +1,32 @@
+package com.jame.dev.gymApp.aspects.imp.constraints;
+
+import com.jame.dev.gymApp.aspects.annotations.constraints.SortPropertyValid;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public class SortPropertyValidConstraint implements ConstraintValidator<SortPropertyValid, Pageable> {
+
+   private static final Set<String> WHITE_LIST = Set.of(
+      "id", "name", "email",
+      "userEmail", "pricing", "finished"
+   );
+
+   private final Predicate<String> isInvalidProperty = prop -> !WHITE_LIST.contains(prop) && !prop.contains(".");
+
+   @Override
+   public boolean isValid(Pageable value, ConstraintValidatorContext context) {
+      if(value == null) return true;
+
+      return value.getSort()
+         .stream()
+         .map(Sort.Order::getProperty)
+         .map(p -> p.toLowerCase(Locale.ROOT))
+         .noneMatch(isInvalidProperty);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/config/app/AppConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/config/app/AppConfig.java
@@ -3,9 +3,11 @@ package com.jame.dev.gymApp.config.app;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 import java.time.Clock;
@@ -18,14 +20,36 @@ public class AppConfig {
 
    @Bean(name = "mapper")
    @Primary
-   public ObjectMapper mapper(){
+   public ObjectMapper mapper() {
       return new ObjectMapper()
-              .registerModule(new JavaTimeModule())
-              .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+         .registerModule(new JavaTimeModule())
+         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
    }
 
    @Bean(name = "clock")
-   public Clock clock(){
+   public Clock clock() {
       return Clock.systemUTC();
+   }
+
+   @Bean("pageKeyGenerator")
+   public KeyGenerator pageKeyGenerator() {
+      return (ignoredTarget, ignoredMethod, params) -> {
+         final StringBuilder sb = new StringBuilder();
+         for (Object param : params) {
+            if(param == null) continue;
+            if(param instanceof Pageable pag) {
+               sb.append(pag.getPageNumber())
+                  .append(":");
+               sb.append(pag.getPageSize())
+                  .append(":sort=");
+               sb.append(pag.getSort());
+            }
+
+            if(param instanceof String s) {
+               sb.append(":").append(s);
+            }
+         }
+         return sb.toString();
+      };
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/CustomerController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/CustomerController.java
@@ -11,6 +11,9 @@ import com.jame.dev.gymApp.service.in.CustomerService;
 import jakarta.validation.Valid;
 import lombok.NonNull;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -32,10 +35,12 @@ public class CustomerController extends BaseController<CustomerDtoOutput, Custom
    }
 
    @GetMapping
-   public ResponseEntity<@NonNull Page<@NonNull CustomerDtoOutput>> getPage(
-      @RequestParam("page") final int page,
-      @RequestParam("size") final int size) {
-      return super.getPage(page, size);
+   public ResponseEntity<@NonNull Page<@NonNull CustomerDtoOutput>> getCustomerPage(
+      @PageableDefault(
+         sort = "id",
+         direction = Sort.Direction.DESC) final Pageable pageable,
+      @RequestParam(required = false, name = "search") String search) {
+      return super.getPage(pageable, search);
    }
 
    @GetMapping("/{id}")

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionController.java
@@ -9,6 +9,9 @@ import com.jame.dev.gymApp.service.in.SubscriptionService;
 import jakarta.validation.Valid;
 import lombok.NonNull;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -25,9 +28,11 @@ public class SubscriptionController extends
 
    @GetMapping
    public ResponseEntity<@NonNull Page<@NonNull SubscriptionDtoOutput>> getSubscriptionPage(
-           @RequestParam("page") final int page,
-           @RequestParam("size") final int size) {
-      return super.getPage(page, size);
+      @PageableDefault(
+         sort = "id",
+         direction = Sort.Direction.DESC) final Pageable pageable,
+      @RequestParam(required = false, name = "search") String search) {
+      return super.getPage(pageable, search);
    }
 
    @GetMapping("/{id}")

--- a/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/UserController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/routes/app/admin/UserController.java
@@ -12,6 +12,9 @@ import com.jame.dev.gymApp.service.in.UserService;
 import jakarta.validation.Valid;
 import lombok.NonNull;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -32,10 +35,12 @@ public class UserController extends BaseController<UserDtoOutput, UserDtoInput> 
    }
 
    @GetMapping
-   public ResponseEntity<@NonNull Page<@NonNull UserDtoOutput>> getUsers(
-      @RequestParam("page") final int page,
-      @RequestParam("size") final int size) {
-      return super.getPage(page, size);
+   public ResponseEntity<@NonNull Page<@NonNull UserDtoOutput>> getUsersPage(
+      @PageableDefault(
+         sort = "id",
+         direction = Sort.Direction.DESC) final Pageable pageable,
+      @RequestParam(required = false, name = "search") String search) {
+      return super.getPage(pageable, search);
    }
 
    @GetMapping("/inactive")

--- a/src/main/java/com/jame/dev/gymApp/controller/service/BaseController.java
+++ b/src/main/java/com/jame/dev/gymApp/controller/service/BaseController.java
@@ -6,7 +6,9 @@ import com.jame.dev.gymApp.model.dto.out.PageDto;
 import com.jame.dev.gymApp.service.common.BaseService;
 import jakarta.validation.Valid;
 import lombok.NonNull;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -27,11 +29,9 @@ public abstract class BaseController<OUT, IN> {
       this.idExtractor = idExtractor;
    }
 
-   public ResponseEntity<@NonNull Page<@NonNull OUT>> getPage(
-           final int page,
-           final int size) {
-      final Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
-      final PageDto<@NonNull OUT> dtoPage = service.getPage(pageable);
+   protected ResponseEntity<@NonNull Page<@NonNull OUT>> getPage(
+      final Pageable pageable, final String search) {
+      final PageDto<@NonNull OUT> dtoPage = service.getPage(pageable, search);
       final Page<OUT> response = new PageImpl<>(dtoPage.content(), pageable, dtoPage.totalElements());
       return ResponseEntity.ok(response);
    }
@@ -44,26 +44,24 @@ public abstract class BaseController<OUT, IN> {
    protected ResponseEntity<@NonNull OUT> create(final IN dto) {
       final OUT response = service.save(dto);
       final URI created = ServletUriComponentsBuilder
-              .fromCurrentRequest()
-              .path("/{id}")
-              .buildAndExpand(idExtractor.apply(response))
-              .toUri();
+         .fromCurrentRequest()
+         .path("/{id}")
+         .buildAndExpand(idExtractor.apply(response))
+         .toUri();
       return ResponseEntity.created(created)
-              .body(response);
+         .body(response);
    }
 
    protected ResponseEntity<@NonNull OUT> update(
-           @Minimum
-           final long id,
-           @Valid
-           @NotNullObject(message = "Payload must not be null") final IN dto) {
+      @Minimum final long id,
+      @Valid
+      @NotNullObject(message = "Payload must not be null") final IN dto) {
       final OUT response = service.update(id, dto);
       return ResponseEntity.ok(response);
    }
 
    protected ResponseEntity<Void> delete(
-           @Minimum
-           final long id) {
+      @Minimum final long id) {
       service.softDelete(id);
       return ResponseEntity.noContent().build();
    }

--- a/src/main/java/com/jame/dev/gymApp/repository/common/CustomJpaRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/repository/common/CustomJpaRepository.java
@@ -2,9 +2,12 @@ package com.jame.dev.gymApp.repository.common;
 
 import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.repository.NoRepositoryBean;
 
 
 @NoRepositoryBean
-public interface CustomJpaRepository<T, ID> extends JpaRepository<@NonNull T, @NonNull ID> {
+public interface CustomJpaRepository<T, ID> extends 
+   JpaRepository<@NonNull T, @NonNull ID>,
+   JpaSpecificationExecutor<T> {
 }

--- a/src/main/java/com/jame/dev/gymApp/service/common/BaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/service/common/BaseService.java
@@ -2,13 +2,14 @@ package com.jame.dev.gymApp.service.common;
 
 import com.jame.dev.gymApp.aspects.annotations.constraints.Minimum;
 import com.jame.dev.gymApp.aspects.annotations.constraints.NotNullObject;
+import com.jame.dev.gymApp.aspects.annotations.constraints.SortPropertyValid;
 import com.jame.dev.gymApp.model.dto.out.PageDto;
 import jakarta.validation.Valid;
 import lombok.NonNull;
 import org.springframework.data.domain.Pageable;
 
 public interface BaseService<DTO_OUT, DTO_IN> {
-   PageDto<@NonNull DTO_OUT> getPage(@NotNullObject @Valid final Pageable pageable);
+   PageDto<@NonNull DTO_OUT> getPage(@SortPropertyValid final Pageable pageable, final String search);
 
    DTO_OUT save(@NotNullObject @Valid final DTO_IN dtoIn);
 

--- a/src/main/java/com/jame/dev/gymApp/service/out/CustomerServiceImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/CustomerServiceImplementation.java
@@ -14,6 +14,7 @@ import com.jame.dev.gymApp.repository.CustomerRepository;
 import com.jame.dev.gymApp.service.in.CustomerRecoverService;
 import com.jame.dev.gymApp.service.in.CustomerService;
 import com.jame.dev.gymApp.shared.enums.CacheValues;
+import com.jame.dev.gymApp.specifications.CustomerSpecification;
 import com.jame.dev.gymApp.updaters.in.CustomerUpdater;
 import com.jame.dev.gymApp.validators.CustomerValidator;
 import lombok.NonNull;
@@ -22,6 +23,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -43,11 +45,12 @@ public class CustomerServiceImplementation implements CustomerService, CustomerR
    @Transactional(readOnly = true)
    @Cacheable(
       value = CUSTOMERS,
-      key = "#pageable.pageNumber + ':' + #pageable.pageSize",
+      keyGenerator = "pageKeyGenerator",
       unless = "#result == null || #result.content.isEmpty()"
    )
-   public PageDto<CustomerDtoOutput> getPage(Pageable pageable) {
-      final Page<CustomerEntity> page = repo.findAll(pageable);
+   public PageDto<CustomerDtoOutput> getPage(Pageable pageable, String search) {
+      final Specification<CustomerEntity> spec = new CustomerSpecification(search);
+      final Page<CustomerEntity> page = repo.findAll(spec, pageable);
       return customerFactory.createPageFrom(page);
    }
 

--- a/src/main/java/com/jame/dev/gymApp/service/out/SubscriptionServiceImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/SubscriptionServiceImplementation.java
@@ -18,14 +18,15 @@ import com.jame.dev.gymApp.repository.PricingRepository;
 import com.jame.dev.gymApp.repository.SubscriptionRepository;
 import com.jame.dev.gymApp.service.in.SubscriptionService;
 import com.jame.dev.gymApp.shared.enums.CacheValues;
+import com.jame.dev.gymApp.specifications.SubscriptionSpecification;
 import com.jame.dev.gymApp.updaters.in.SubscriptionUpdater;
 import com.jame.dev.gymApp.validators.SubscriptionValidator;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -49,11 +50,12 @@ public class SubscriptionServiceImplementation implements SubscriptionService {
    @Transactional(readOnly = true)
    @Cacheable(
       value = CacheValues.SUBSCRIPTIONS,
-      key = "#pageable.pageNumber + ':' + #pageable.pageSize",
+      keyGenerator = "pageKeyGenerator",
       unless = "#result == null || #result.content.isEmpty()"
    )
-   public PageDto<SubscriptionDtoOutput> getPage(@NonNull Pageable pageable) {
-      final Page<SubscriptionEntity> entityPage = repo.findAll(pageable);
+   public PageDto<SubscriptionDtoOutput> getPage(Pageable pageable, String search) {
+      final Specification<SubscriptionEntity> spec = new SubscriptionSpecification(search);
+      final Page<SubscriptionEntity> entityPage = repo.findAll(spec, pageable);
       return subscriptionFactory.createPageFrom(entityPage);
    }
 

--- a/src/main/java/com/jame/dev/gymApp/service/out/UserServiceImplementation.java
+++ b/src/main/java/com/jame/dev/gymApp/service/out/UserServiceImplementation.java
@@ -16,6 +16,7 @@ import com.jame.dev.gymApp.service.in.UserInactiveService;
 import com.jame.dev.gymApp.service.in.UserService;
 import com.jame.dev.gymApp.shared.enums.CacheValues;
 import com.jame.dev.gymApp.shared.enums.Role;
+import com.jame.dev.gymApp.specifications.UserSpecifications;
 import com.jame.dev.gymApp.updaters.in.UserUpdater;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -51,11 +53,12 @@ public class UserServiceImplementation implements
    @Transactional(readOnly = true)
    @Cacheable(
       value = CacheValues.USERS,
-      key = "#pageable.pageNumber + ':' + #pageable.pageSize",
+      keyGenerator = "pageKeyGenerator",
       unless = "#result == null || #result.content.isEmpty()"
    )
-   public PageDto<UserDtoOutput> getPage(Pageable pageable) {
-      final Page<UserEntity> entityPage = repo.findAll(pageable);
+   public PageDto<UserDtoOutput> getPage(Pageable pageable, String search) {
+      final Specification<UserEntity> spec = new UserSpecifications(search);
+      final Page<UserEntity> entityPage = repo.findAll(spec, pageable);
       return userFactory.createPageFrom(entityPage);
    }
 

--- a/src/main/java/com/jame/dev/gymApp/specifications/CustomerSpecification.java
+++ b/src/main/java/com/jame/dev/gymApp/specifications/CustomerSpecification.java
@@ -1,0 +1,29 @@
+package com.jame.dev.gymApp.specifications;
+
+import com.jame.dev.gymApp.entity.CustomerEntity;
+import com.jame.dev.gymApp.entity.UserEntity;
+import jakarta.persistence.criteria.*;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.jpa.domain.Specification;
+
+public class CustomerSpecification implements Specification<CustomerEntity> {
+   private final String search;
+
+   @Override
+   public @Nullable Predicate toPredicate(Root<CustomerEntity> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+      if (search == null || search.isBlank()) return cb.conjunction();
+
+      final String like = "%" + search.toLowerCase() + "%";
+
+      final Join<CustomerEntity, UserEntity> userJoin = root.join("user", JoinType.LEFT);
+      query.distinct(true);
+
+      return cb.or(
+        cb.like(cb.lower(userJoin.get("email")), like)
+      );
+   }
+
+   public CustomerSpecification(String search) {
+      this.search = search;
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/specifications/SubscriptionSpecification.java
+++ b/src/main/java/com/jame/dev/gymApp/specifications/SubscriptionSpecification.java
@@ -1,0 +1,34 @@
+package com.jame.dev.gymApp.specifications;
+
+import com.jame.dev.gymApp.entity.*;
+import jakarta.persistence.criteria.*;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.jpa.domain.Specification;
+
+public class SubscriptionSpecification implements Specification<SubscriptionEntity> {
+
+   private final String search;
+
+   @Override
+   public @Nullable Predicate toPredicate(Root<SubscriptionEntity> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+      if (search == null || search.isBlank()) return cb.conjunction();
+
+      final String like = "%" + search.toLowerCase() + "%";
+
+      final Join<SubscriptionEntity, PricingEntity> ignoredpricingJoin = root.join("pricing", JoinType.INNER);
+      final Join<PricingEntity, MemberShipEntity> membershipJoin = root.join("membership", JoinType.INNER);
+      final Join<SubscriptionEntity, CustomerEntity> ignoredCustomerJoin = root.join("customer", JoinType.INNER);
+      final Join<CustomerEntity, UserEntity> userJoin = root.join("user", JoinType.INNER);
+      query.distinct(true);
+
+      return cb.or(
+         cb.like(cb.lower(membershipJoin.get("membership").as(String.class)), like),
+         cb.like(cb.lower(userJoin.get("email")), like),
+         cb.equal(root.get("finished"), Boolean.parseBoolean(like))
+      );
+   }
+
+   public SubscriptionSpecification(String search) {
+      this.search = search;
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/specifications/UserSpecifications.java
+++ b/src/main/java/com/jame/dev/gymApp/specifications/UserSpecifications.java
@@ -1,0 +1,35 @@
+package com.jame.dev.gymApp.specifications;
+
+import com.jame.dev.gymApp.entity.RoleEntity;
+import com.jame.dev.gymApp.entity.UserEntity;
+import jakarta.persistence.criteria.*;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.jpa.domain.Specification;
+
+public class UserSpecifications implements Specification<UserEntity> {
+
+   private final String search;
+
+   @Override
+   public @Nullable Predicate toPredicate(Root<UserEntity> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+      if (search == null || search.isBlank()) {
+         return cb.conjunction();
+      }
+
+      final String like = "%" + search.toLowerCase() + "%";
+
+      final Join<UserEntity, RoleEntity> roleJoin = root.join("roles", JoinType.INNER);
+
+      query.distinct(true);
+
+      return cb.or(
+         cb.like(cb.lower(root.get("name")), like),
+         cb.like(cb.lower(root.get("email")), like),
+         cb.equal(cb.upper(roleJoin.get("role").as(String.class)), search.toUpperCase())
+      );
+   }
+
+   public UserSpecifications(String search) {
+      this.search = search;
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/validators/PageableValidator.java
+++ b/src/main/java/com/jame/dev/gymApp/validators/PageableValidator.java
@@ -1,0 +1,24 @@
+package com.jame.dev.gymApp.validators;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Set;
+
+public class PageableValidator {
+   private static final Set<String> WHITE_LIST = Set.of(
+      "id", "name", "email",
+      "userEmail", "pricing", "membership"
+   );
+
+   public static Pageable checkSort(Pageable pageable) {
+      final Sort sort = pageable.getSort();
+      for (Sort.Order order : sort) {
+         final String property = order.getProperty();
+         if(!WHITE_LIST.contains(property)) {
+            throw new IllegalArgumentException("Cannot sort by property: " + property);
+         }
+      }
+      return pageable;
+   }
+}


### PR DESCRIPTION
## Description
This PR introduces support for dynamic filtering and advanced querying across core entities by leveraging JPA Specifications. It enhances repository capabilities by integrating `JpaSpecificationExecutor` and adds search-driven filtering to pageable endpoints. Additionally, it improves validation and caching strategies for paginated requests.

## Main Changes
- Extended `CustomJpaRepository` to implement `JpaSpecificationExecutor<T>` enabling specification-based queries.
- Added Specification classes:
  - `UserSpecifications`
  - `CustomerSpecification`
  - `SubscriptionSpecification`  
  Each supports a `search` parameter for dynamic filtering.
- Updated service layer (`UserServiceImplementation`, `CustomerServiceImplementation`, `SubscriptionServiceImplementation`) to use specifications with `findAll(spec, pageable)`.
- Refactored `BaseService#getPage` to accept a `search` parameter and validated `Pageable`.
- Updated controllers to:
  - Use `Pageable` with `@PageableDefault`
  - Accept optional `search` query param
- Introduced `SortPropertyValid` annotation and its validator to enforce allowed sorting properties.
- Added custom `pageKeyGenerator` for improved cache key generation including pagination and search parameters.

## Minimal Changes
- Refactored method signatures for consistency (e.g., `getPage(pageable, search)`).
- Minor formatting and indentation improvements.
- Renamed controller methods for clarity (`getUsersPage`, `getCustomerPage`, etc.).
- Adjusted imports and removed unused ones.

## Notes
- Current Specifications are basic and can be extended to include more fields and complex predicates.
- Sorting validation is whitelist-based; future improvements could make this dynamic or entity-driven.
- Consider adding unit and integration tests for specification filtering behavior.
- Potential enhancement: centralize Specification building to reduce duplication.
- The `search` parameter parsing (e.g., boolean handling in `SubscriptionSpecification`) could be refined for robustness.