### PR TITLE
fix: Fixed specifications, make correct use for the Joins andthe resu…

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/specification/SubscriptionSpecification.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/specification/SubscriptionSpecification.java
@@ -9,6 +9,10 @@ import jakarta.persistence.criteria.*;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
 public class SubscriptionSpecification implements Specification<SubscriptionEntity> {
 
    private final String search;
@@ -18,18 +22,39 @@ public class SubscriptionSpecification implements Specification<SubscriptionEnti
       if (search == null || search.isBlank()) return cb.conjunction();
 
       final String like = "%" + search.toLowerCase() + "%";
+      final String trimmed = search.trim();
 
-      final Join<SubscriptionEntity, PricingEntity> ignoredpricingJoin = root.join("pricing", JoinType.INNER);
-      final Join<PricingEntity, MemberShipEntity> membershipJoin = root.join("membership", JoinType.INNER);
-      final Join<SubscriptionEntity, CustomerEntity> ignoredCustomerJoin = root.join("customer", JoinType.INNER);
-      final Join<CustomerEntity, UserEntity> userJoin = root.join("user", JoinType.INNER);
+      final Join<SubscriptionEntity, PricingEntity> pricingJoin = root.join("pricing", JoinType.LEFT);
+      final Join<PricingEntity, MemberShipEntity> membershipJoin = pricingJoin.join("memberShipEntity", JoinType.LEFT);
+      final Join<SubscriptionEntity, CustomerEntity> customerJoin = root.join("customer", JoinType.LEFT);
+      final Join<CustomerEntity, UserEntity> userJoin = customerJoin.join("user", JoinType.LEFT);
+
       query.distinct(true);
 
-      return cb.or(
-         cb.like(cb.lower(membershipJoin.get("membership").as(String.class)), like),
-         cb.like(cb.lower(userJoin.get("email")), like),
-         cb.equal(root.get("finished"), Boolean.parseBoolean(like))
-      );
+      final List<Predicate> predicates = new ArrayList<>();
+      predicates.add(cb.like(cb.lower(userJoin.get("email")), like));
+
+      predicates.add(cb.equal(
+         cb.lower(membershipJoin.get("membership")).as(String.class),
+         trimmed.toLowerCase()
+      ));
+
+      try {
+         BigDecimal price = new BigDecimal(trimmed);
+         predicates.add(cb.equal(
+            pricingJoin.get("price").as(BigDecimal.class),
+            price
+         ));
+      } catch (NumberFormatException ignored) {}
+
+      if ("true".equalsIgnoreCase(trimmed) || "false".equalsIgnoreCase(trimmed)) {
+         predicates.add(cb.equal(
+            root.get("finished").as(Boolean.class),
+            Boolean.parseBoolean(trimmed)
+         ));
+      }
+
+      return cb.or(predicates.toArray(new Predicate[0]));
    }
 
    public SubscriptionSpecification(String search) {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -8,7 +8,7 @@ app.auth.redirect.url.password-reset=http://localhost:5173/password-reset
 
 # JPA DEV
 spring.jpa.hibernate.ddl-auto=create
-spring.jpa.show-sql=true
+#spring.jpa.show-sql=true
 
 # DATASOURCE DEV
 spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
# Description

This PR fixes and improves the subscription search specification by correctly configuring entity joins and applying the appropriate comparison strategy depending on the searched property. The implementation now differentiates between partial text matching and exact value comparisons, resulting in more accurate filtering behavior and better query reliability.

# Main Changes

* Refactored `SubscriptionSpecification` to correctly navigate entity relationships using dedicated join objects.
* Fixed join usage between:

  * Subscription → Pricing
  * Pricing → Membership
  * Subscription → Customer
  * Customer → User
* Replaced incorrect root-level joins with properly chained joins based on entity relationships.
* Added support for exact membership searches using equality comparisons instead of wildcard matching.
* Added support for exact price searches by parsing the search value into `BigDecimal`.
* Added support for boolean filtering on the `finished` field when the search value is `true` or `false`.
* Maintained partial matching behavior for customer user email searches using `LIKE`.
* Introduced dynamic predicate generation to combine multiple filtering strategies in a single specification.
* Enabled distinct query results to prevent duplicated records caused by joins.

# Minimal Changes

* Added required imports for:

  * `BigDecimal`
  * `ArrayList`
  * `List`
* Introduced a trimmed search value to normalize user input before comparisons.
* Removed unused and incorrectly named join variables.
* Commented out the `spring.jpa.show-sql` property in the development configuration.

# Notes

* Equality-based comparisons provide more predictable results for strongly typed fields such as memberships, prices, and boolean statuses.
* Future improvements could include detecting additional data types (dates, enums, identifiers) and automatically selecting the most appropriate comparison strategy.
* Consider extracting predicate-building logic into dedicated helper methods to improve maintainability as filtering requirements grow.
* If additional searchable fields are added in the future, maintaining a clear distinction between exact-match and fuzzy-search fields will help preserve query performance and correctness.
