### PR TITLE
AuditLogResponse

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/audit/api/AuditLogController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/api/AuditLogController.java
@@ -5,7 +5,6 @@ import com.jame.dev.gymApp.application.dto.PageDto;
 import com.jame.dev.gymApp.features.audit.api.response.AuditLogResponse;
 import com.jame.dev.gymApp.features.audit.application.contract.AuditLogService;
 import lombok.RequiredArgsConstructor;
-import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +12,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,10 +28,5 @@ public class AuditLogController {
       final PageDto<AuditLogResponse> pageDto = auditLogService.getPage(pageable);
       final Page<AuditLogResponse> page = new PageImpl<>(pageDto.content(), pageable, pageDto.totalElements());
       return ResponseEntity.ok(page);
-   }
-
-   @GetMapping("/{id}")
-   public ResponseEntity<AuditLogResponse> getAuditLogById(@PathVariable ObjectId id) {
-      return ResponseEntity.ok(auditLogService.getById(id));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/audit/api/response/AuditLogResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/api/response/AuditLogResponse.java
@@ -10,7 +10,6 @@ import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import java.time.Instant;
 
 public record AuditLogResponse(
-   @JsonProperty("id") String id,
    @JsonProperty("entity") AuditLogEntity entity,
    @JsonProperty("action") AuditLogAction action,
    @JsonProperty("actor") AuditLogActor actor,

--- a/src/main/java/com/jame/dev/gymApp/features/audit/application/contract/AuditLogService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/application/contract/AuditLogService.java
@@ -2,10 +2,8 @@ package com.jame.dev.gymApp.features.audit.application.contract;
 
 import com.jame.dev.gymApp.application.dto.PageDto;
 import com.jame.dev.gymApp.features.audit.api.response.AuditLogResponse;
-import org.bson.types.ObjectId;
 import org.springframework.data.domain.Pageable;
 
 public interface AuditLogService {
    PageDto<AuditLogResponse> getPage(final Pageable pageable);
-   AuditLogResponse getById(ObjectId id);
 }

--- a/src/main/java/com/jame/dev/gymApp/features/audit/application/service/AuditLogApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/application/service/AuditLogApplicationService.java
@@ -4,10 +4,8 @@ import com.jame.dev.gymApp.application.dto.PageDto;
 import com.jame.dev.gymApp.features.audit.api.response.AuditLogResponse;
 import com.jame.dev.gymApp.features.audit.application.contract.AuditLogService;
 import com.jame.dev.gymApp.features.audit.application.support.factory.AuditLogFactory;
-import com.jame.dev.gymApp.features.audit.domain.exception.AuditLogNotFoundException;
 import com.jame.dev.gymApp.features.audit.domain.repository.AuditLogRepository;
 import lombok.RequiredArgsConstructor;
-import org.bson.types.ObjectId;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -27,17 +25,5 @@ public class AuditLogApplicationService implements AuditLogService {
    )
    public PageDto<AuditLogResponse> getPage(Pageable pageable) {
       return auditLogFactory.createPageFrom(auditLogRepository.findAll(pageable));
-   }
-
-   @Override
-   @Cacheable(
-      value = "auditLog",
-      key = "#id",
-      cacheManager = "redisCacheManager"
-   )
-   public AuditLogResponse getById(ObjectId id) {
-      return auditLogRepository.findById(id)
-         .map(auditLogFactory::createFromEntity)
-         .orElseThrow(() -> new AuditLogNotFoundException("Audit Log Document not found." + id));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/audit/application/support/mapper/AuditLogMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/application/support/mapper/AuditLogMapper.java
@@ -14,10 +14,6 @@ public interface AuditLogMapper extends BaseMapper<AuditLogDocument, AuditLogRes
    @Override
    AuditLogResponse toDto(final AuditLogDocument entity);
 
-   default String map(ObjectId value) {
-      return value != null ? value.toHexString() : null;
-   }
-
    default AuditLogDocument toEntity(AuditLogInput auditLogInput) {
       return AuditLogDocument.builder()
          .id(ObjectId.get())


### PR DESCRIPTION
## Description

This PR introduces changes on `audit` domain's, mainly in `AuditLogResponse` record class, because the property 'id' wasn't being used. so it was removed, also endpoint to consult one audit record by the 'id' was removed too.

---

## Changes

- `AuditLogResponse`: Removed **id** property.
- `AuditLogMapper`:  Erased default method to map the `ObjectId`.
- `AuditLogService`: Drop off method `getById` because it's not used.
- `AuditLogController`: Endpoint `/{id}` dropped off due to an unused behavior. 

---