### PR TITLE
Subscription use cases

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/audit/application/support/resolver/AuditIdQueryBeforeResolver.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/application/support/resolver/AuditIdQueryBeforeResolver.java
@@ -6,7 +6,7 @@ import com.jame.dev.gymApp.features.customer.domain.exception.CustomerNotFoundEx
 import com.jame.dev.gymApp.features.customer.infrastructure.persistence.CustomerRepository;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
 import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
-import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
 import com.jame.dev.gymApp.features.user.application.support.mapper.RoleMapper;
 import com.jame.dev.gymApp.features.user.domain.exception.UserEntityNotFoundException;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionAdministrationController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionAdministrationController.java
@@ -1,56 +1,72 @@
 package com.jame.dev.gymApp.features.subscription.api;
 
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.*;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByIdSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetPageSubscriptionUseCase;
 import com.jame.dev.gymApp.features.subscription.infrastructure.notification.service.SubscriptionNotificationAppService;
 import com.jame.dev.gymApp.infrastructure.annotation.Minimum;
 import com.jame.dev.gymApp.infrastructure.annotation.NotNullObject;
-import com.jame.dev.gymApp.infrastructure.web.FullController;
-import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
-import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
-import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionService;
 import jakarta.validation.Valid;
-import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/app/v1/administration/subs")
 @PreAuthorize("hasRole('ADMIN')")
-public class SubscriptionAdministrationController extends
-   FullController<SubscriptionResponse, SubscriptionRequest> {
+@RequiredArgsConstructor
+@Validated
+public class SubscriptionAdministrationController {
 
+   private final GetPageSubscriptionUseCase subscriptionGetPage;
+   private final GetByIdSubscriptionUseCase subscriptionGetById;
+   private final CreateSubscriptionUseCase subscriptionCreate;
+   private final UpdateSubscriptionUseCase subscriptionUpdate;
+   private final RenewSubscriptionUseCase subscriptionRenew;
+   private final FinalizeSubscriptionUseCase subscriptionFinalize;
+   private final SoftDeleteSubscriptionByIdUseCase subscriptionSoftDelete;
    private final SubscriptionNotificationAppService subsNotificationAppService;
 
-   public SubscriptionAdministrationController(
-      final SubscriptionService service,
-      final SubscriptionNotificationAppService subsNotificationAppService) {
-      super(service, SubscriptionResponse::id);
-      this.subsNotificationAppService = subsNotificationAppService;
-   }
-
    @GetMapping
-   public ResponseEntity<@NonNull Page<@NonNull SubscriptionResponse>> getSubscriptionPage(
+   public ResponseEntity<Page<SubscriptionResponse>> getPage(
       @PageableDefault(
          sort = "id",
          direction = Sort.Direction.DESC) final Pageable pageable,
-      @RequestParam(required = false, name = "search") String search) {
-      return super.getPage(pageable, search);
+      @RequestParam(required = false, name = "search") final String search) {
+      final PageDto<SubscriptionResponse> pageDto = subscriptionGetPage.getPage(pageable, search);
+      final Page<SubscriptionResponse> page = new PageImpl<>(pageDto.content(), pageable, pageDto.totalElements());
+      return ResponseEntity.ok(page);
    }
 
    @GetMapping("/{id}")
-   public ResponseEntity<@NonNull SubscriptionResponse> getSubscription(
+   public ResponseEntity<SubscriptionResponse> getById(
            @PathVariable("id") @Minimum final long id) {
-      return super.getOne(id);
+      final SubscriptionResponse response = subscriptionGetById.getById(id);
+      return ResponseEntity.ok(response);
    }
 
    @PostMapping
-   public ResponseEntity<@NonNull SubscriptionResponse> postSubscription(
+   public ResponseEntity<SubscriptionResponse> create(
            @RequestBody @Valid @NotNullObject final SubscriptionRequest subscriptionRequest) {
-      return super.create(subscriptionRequest);
+      final SubscriptionResponse response = subscriptionCreate.create(subscriptionRequest);
+      final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+              .path("/{id}")
+              .buildAndExpand(response.id())
+              .toUri();
+      return ResponseEntity.created(location).body(response);
    }
 
    @PostMapping("/notify")
@@ -60,38 +76,41 @@ public class SubscriptionAdministrationController extends
    }
 
    @PutMapping("/{id}")
-   public ResponseEntity<@NonNull SubscriptionResponse> updateSubscription(
+   public ResponseEntity<SubscriptionResponse> update(
            @PathVariable("id")
            @Minimum final long id,
            @RequestBody
            @Valid
            @NotNullObject final SubscriptionRequest subscriptionRequest) {
-      return super.update(id, subscriptionRequest);
+      final SubscriptionResponse response = subscriptionUpdate.update(id, subscriptionRequest);
+      return ResponseEntity.ok(response);
    }
 
-
    @PutMapping("/{id}/renew")
-   public ResponseEntity<@NonNull SubscriptionResponse> renewSubscription(
+   public ResponseEntity<SubscriptionResponse> renew(
            @PathVariable("id")
            @Minimum final long id,
            @RequestBody
            @Valid
            @NotNullObject final SubscriptionRequest subscriptionRequest) {
-      return super.put(id, subscriptionRequest);
+      final SubscriptionResponse response = subscriptionRenew.renew(id, subscriptionRequest);
+      return ResponseEntity.ok(response);
    }
 
    @PatchMapping("/{id}")
-   public ResponseEntity<@NonNull SubscriptionResponse> finalizeSubscription(
+   public ResponseEntity<SubscriptionResponse> finalize(
            @PathVariable("id")
            @Minimum final long id) {
-      return super.patch(id);
+      final SubscriptionResponse response = subscriptionFinalize.finalize(id);
+      return ResponseEntity.ok(response);
    }
 
    @DeleteMapping("/{id}")
-   public ResponseEntity<Void> deleteSubscription(
+   public ResponseEntity<Void> delete(
            @PathVariable("id")
            @Minimum final long id) {
-      return super.delete(id);
+      subscriptionSoftDelete.softDeleteById(id);
+      return ResponseEntity.noContent().build();
    }
 }
 

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionUserController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionUserController.java
@@ -1,60 +1,71 @@
 package com.jame.dev.gymApp.features.subscription.api;
 
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.FinalizeSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.RenewSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.UpdateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByEmailSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByIdSubscriptionUseCase;
 import com.jame.dev.gymApp.infrastructure.annotation.EmailValid;
 import com.jame.dev.gymApp.infrastructure.annotation.Minimum;
 import com.jame.dev.gymApp.infrastructure.annotation.NotNullObject;
-import com.jame.dev.gymApp.infrastructure.web.FullControllerIdentifiable;
-import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
-import com.jame.dev.gymApp.application.support.mapper.BaseMapper;
-import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
-import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
-import com.jame.dev.gymApp.application.contract.EmailIdentifiable;
-import com.jame.dev.gymApp.application.contract.FullService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/app/v1/subscriptions")
 @PreAuthorize("hasRole('USER')")
+@RequiredArgsConstructor
 @Validated
-public class SubscriptionUserController extends FullControllerIdentifiable<
-        SubscriptionEntity, SubscriptionResponse, SubscriptionRequest> {
-
-   protected SubscriptionUserController(
-      FullService<SubscriptionResponse, SubscriptionRequest> service,
-      EmailIdentifiable<SubscriptionEntity> identifiable,
-      BaseMapper<SubscriptionEntity, SubscriptionResponse> mapper) {
-      super(service, SubscriptionResponse::id, identifiable, mapper);
-   }
+public class SubscriptionUserController {
+   private final GetByIdSubscriptionUseCase subscriptionGetById;
+   private final GetByEmailSubscriptionUseCase subscriptionGetByEmail;
+   private final CreateSubscriptionUseCase subscriptionCreate;
+   private final UpdateSubscriptionUseCase subscriptionUpdate;
+   private final RenewSubscriptionUseCase subscriptionRenew;
+   private final FinalizeSubscriptionUseCase subscriptionFinalize;
 
    @PreAuthorize("@subscriptionSecurity.isOwner(#id, authentication)")
    @GetMapping("/{id}")
-   public ResponseEntity<SubscriptionResponse> getSub(
+   public ResponseEntity<SubscriptionResponse> getById(
            @PathVariable("id")
            @Minimum
            final long id) {
-      return super.getOne(id);
+      final SubscriptionResponse response = subscriptionGetById.getById(id);
+      return ResponseEntity.ok(response);
    }
 
    @PreAuthorize("@subscriptionSecurity.isOwner(#email, authentication)")
-   @GetMapping("/customer/{email}")
-   public ResponseEntity<SubscriptionResponse> getSubByEmail(
+   @GetMapping("/{email}/customers")
+   public ResponseEntity<SubscriptionResponse> getByEmail(
            @PathVariable("email")
            @EmailValid
            final String email) {
-      return super.getByEmail(email);
+      final SubscriptionResponse response = subscriptionGetByEmail.getByEmail(email);
+      return ResponseEntity.ok(response);
    }
 
    @PreAuthorize("@subscriptionSecurity.isOwner(#input, authentication)")
    @PostMapping
-   public ResponseEntity<SubscriptionResponse> subscribe(
+   public ResponseEntity<SubscriptionResponse> create(
            @Valid
            @RequestBody
            @NotNullObject final SubscriptionRequest input) {
-      return super.create(input);
+      final SubscriptionResponse response = subscriptionCreate.create(input);
+      final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+              .path("/{id}")
+              .buildAndExpand(response.id())
+              .toUri();
+      return ResponseEntity.created(location).body(response);
    }
 
    @PreAuthorize("@subscriptionSecurity.isOwner(#id, authentication)")
@@ -64,16 +75,17 @@ public class SubscriptionUserController extends FullControllerIdentifiable<
            @Minimum final long id,
            @Valid
            @RequestBody
-           @NotNullObject final SubscriptionRequest input
-   ) {
-      return super.put(id, input);
+           @NotNullObject final SubscriptionRequest input) {
+      final SubscriptionResponse response = subscriptionRenew.renew(id, input);
+      return ResponseEntity.ok(response);
    }
 
    @PreAuthorize("@subscriptionSecurity.isOwner(#id, authentication)")
    @PatchMapping("/{id}")
-   public ResponseEntity<SubscriptionResponse> finalizeSubscription(
+   public ResponseEntity<SubscriptionResponse> finalize(
            @PathVariable("id")
            @Minimum final long id) {
-      return super.patch(id);
+      final SubscriptionResponse response = subscriptionFinalize.finalize(id);
+      return ResponseEntity.ok(response);
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/MembershipApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/MembershipApplicationService.java
@@ -1,7 +1,7 @@
 package com.jame.dev.gymApp.features.subscription.application.service;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.MemberShipEntity;
-import com.jame.dev.gymApp.features.subscription.domain.repository.MembershipRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.MembershipRepository;
 import com.jame.dev.gymApp.features.subscription.application.contract.MembershipService;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import lombok.NonNull;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/PeriodApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/PeriodApplicationService.java
@@ -1,7 +1,7 @@
 package com.jame.dev.gymApp.features.subscription.application.service;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.PeriodEntity;
-import com.jame.dev.gymApp.features.subscription.domain.repository.PeriodRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PeriodRepository;
 import com.jame.dev.gymApp.features.subscription.application.contract.PeriodService;
 import com.jame.dev.gymApp.features.subscription.domain.model.Period;
 import lombok.NonNull;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/PricingApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/PricingApplicationService.java
@@ -1,7 +1,7 @@
 package com.jame.dev.gymApp.features.subscription.application.service;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
-import com.jame.dev.gymApp.features.subscription.domain.repository.PricingRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
 import com.jame.dev.gymApp.features.subscription.application.contract.PricingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/SubscriptionApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/SubscriptionApplicationService.java
@@ -20,8 +20,8 @@ import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoun
 import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
 import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
-import com.jame.dev.gymApp.features.subscription.domain.repository.PricingRepository;
-import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
 import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
 import com.jame.dev.gymApp.features.subscription.infrastructure.specification.SubscriptionSpecification;
 import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
@@ -77,13 +77,13 @@ public class SubscriptionApplicationService implements SubscriptionService {
    @Transactional(readOnly = true)
    @Override
    public Optional<SubscriptionEntity> getByEmail(String email) {
-      return repo.findActiveSubscriptionByEmail(email);
+      return repo.findByCustomerEmail(email);
    }
 
    @Override
    @Transactional(readOnly = true)
    public boolean exitsByIdAndCustomerEmail(long id, String email) {
-      return repo.existsByIdAndCustomer_User_EmailAndActiveTrue(id, email);
+      return repo.existsByIdAndCustomer_User_Email(id, email);
    }
 
    @Override

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreateSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreateSubscriptionUseCaseService.java
@@ -1,0 +1,67 @@
+package com.jame.dev.gymApp.features.subscription.application.service.mutation;
+
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
+import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException;
+import com.jame.dev.gymApp.features.customer.domain.exception.CustomerNotFoundException;
+import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
+import com.jame.dev.gymApp.features.customer.domain.repository.CustomerQueryRepository;
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.dto.SubscriptionFactoryDtoInput;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionValidationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTIONS;
+
+@Service
+@RequiredArgsConstructor
+public class CreateSubscriptionUseCaseService implements CreateSubscriptionUseCase {
+    private final SubscriptionMutationRepository subscriptionMutationRepository;
+    private final CustomerQueryRepository customerQueryRepository;
+    private final PricingRepository pricingRepository;
+    private final SubscriptionValidationRepository subscriptionValidationRepository;
+    private final SubscriptionFactory subscriptionFactory;
+
+    @Override
+    @Transactional
+    @CacheEvict(value = SUBSCRIPTIONS, allEntries = true)
+    @AuditLog(
+        action = AuditLogAction.INSERT,
+        entityType = AuditLogEntityType.SUBSCRIPTION,
+        input = "#request",
+        entityId = "#result.id",
+        result = "#result"
+    )
+    public SubscriptionResponse create(SubscriptionRequest request) {
+        final CustomerEntity customer = customerQueryRepository.findByUserEmail(request.customerEmail())
+            .orElseThrow(() -> new CustomerNotFoundException("Customer Not Found."));
+
+        if (subscriptionValidationRepository.existsByCustomer(customer)) {
+            throw new AlreadyExistsException("There's a subscription linked to the customer with: " + request.customerEmail());
+        }
+
+        final PricingEntity pricing = pricingRepository.findByMemberShipEntity_Membership(request.membership())
+            .orElseThrow(() -> new PricingNotFoundException("Pricing Not Found."));
+
+        final SubscriptionEntity subscriptionEntity = subscriptionFactory.createFromInput(
+            new SubscriptionFactoryDtoInput(request, customer, pricing, LocalDate.now()));
+
+        final SubscriptionEntity subscriptionSaved = subscriptionMutationRepository.save(subscriptionEntity);
+
+        return subscriptionFactory.createFromEntity(subscriptionSaved);
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
@@ -1,0 +1,44 @@
+package com.jame.dev.gymApp.features.subscription.application.service.mutation;
+
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
+import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.FinalizeSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class FinalizeSubscriptionUseCaseService implements FinalizeSubscriptionUseCase {
+    private final SubscriptionQueryRepository subscriptionQueryRepository;
+    private final SubscriptionMutationRepository subscriptionMutationRepository;
+    private final SubscriptionFactory subscriptionFactory;
+
+    @Override
+    @Transactional
+    @CacheEvictSubscriptions
+    @AuditLog(
+        action = AuditLogAction.UPDATE,
+        entityType = AuditLogEntityType.SUBSCRIPTION,
+        entityId = "#id",
+        result = "#result"
+    )
+    public SubscriptionResponse finalize(long id) {
+        final SubscriptionEntity subscription = subscriptionQueryRepository.findById(id)
+            .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not Found."));
+        subscription.setFinished(true);
+        subscription.setUpdatedAt(Instant.now());
+        final SubscriptionEntity subscriptionFinalized = subscriptionMutationRepository.save(subscription);
+        return subscriptionFactory.createFromEntity(subscriptionFinalized);
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/RenewSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/RenewSubscriptionUseCaseService.java
@@ -1,0 +1,51 @@
+package com.jame.dev.gymApp.features.subscription.application.service.mutation;
+
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
+import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionUpdater;
+import com.jame.dev.gymApp.features.subscription.application.support.validator.SubscriptionValidator;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.RenewSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RenewSubscriptionUseCaseService implements RenewSubscriptionUseCase {
+    private final SubscriptionValidator validator;
+    private final PricingRepository pricingRepository;
+    private final SubscriptionUpdater subscriptionUpdater;
+    private final SubscriptionMutationRepository subscriptionMutationRepository;
+    private final SubscriptionFactory subscriptionFactory;
+
+    @Override
+    @Transactional
+    @CacheEvictSubscriptions
+    @AuditLog(
+        action = AuditLogAction.UPDATE,
+        entityType = AuditLogEntityType.SUBSCRIPTION,
+        input = "#input",
+        entityId = "#id",
+        result = "#result"
+    )
+    public SubscriptionResponse renew(long id, SubscriptionRequest input) {
+        final SubscriptionEntity subscriptionEntity = validator.validateOnRenew(id, input);
+
+        final PricingEntity pricing = pricingRepository.findByMemberShipEntity_Membership(input.membership())
+            .orElseThrow(() -> new PricingNotFoundException("Pricing not found."));
+
+        subscriptionUpdater.applyRenew(subscriptionEntity, pricing);
+        final SubscriptionEntity subscriptionRenewed = subscriptionMutationRepository.save(subscriptionEntity);
+        return subscriptionFactory.createFromEntity(subscriptionRenewed);
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
@@ -1,0 +1,29 @@
+package com.jame.dev.gymApp.features.subscription.application.service.mutation;
+
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
+import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.SoftDeleteSubscriptionByIdUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SoftDeleteSubscriptionByIdUseCaseService implements SoftDeleteSubscriptionByIdUseCase {
+    private final SubscriptionMutationRepository subscriptionMutationRepository;
+
+    @Override
+    @Transactional
+    @CacheEvictSubscriptions
+    @AuditLog(
+        action = AuditLogAction.DELETE,
+        entityType = AuditLogEntityType.SUBSCRIPTION,
+        entityId = "#id"
+    )
+    public void softDeleteById(long id) {
+        subscriptionMutationRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/UpdateSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/UpdateSubscriptionUseCaseService.java
@@ -1,0 +1,54 @@
+package com.jame.dev.gymApp.features.subscription.application.service.mutation;
+
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
+import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
+import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionUpdater;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.UpdateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateSubscriptionUseCaseService implements UpdateSubscriptionUseCase {
+    private final SubscriptionQueryRepository subscriptionQueryRepository;
+    private final PricingRepository pricingRepository;
+    private final SubscriptionUpdater subscriptionUpdater;
+    private final SubscriptionMutationRepository subscriptionMutationRepository;
+    private final SubscriptionFactory subscriptionFactory;
+
+    @Override
+    @Transactional
+    @CacheEvictSubscriptions
+    @AuditLog(
+        action = AuditLogAction.UPDATE,
+        entityType = AuditLogEntityType.SUBSCRIPTION,
+        input = "#request",
+        entityId = "#id",
+        result = "#result"
+    )
+    public SubscriptionResponse update(long id, SubscriptionRequest request) {
+        final SubscriptionEntity subscriptionEntity = subscriptionQueryRepository.findById(id)
+            .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not Found."));
+
+        final PricingEntity pricingEntity = pricingRepository.findByMemberShipEntity_Membership(request.membership())
+            .orElseThrow(() -> new PricingNotFoundException("Pricing Not Found."));
+
+        subscriptionUpdater.apply(subscriptionEntity, pricingEntity);
+        final SubscriptionEntity subscriptionModified = subscriptionMutationRepository.save(subscriptionEntity);
+
+        return subscriptionFactory.createFromEntity(subscriptionModified);
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetByEmailSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetByEmailSubscriptionUseCaseService.java
@@ -1,0 +1,25 @@
+package com.jame.dev.gymApp.features.subscription.application.service.query;
+
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByEmailSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetByEmailSubscriptionUseCaseService implements GetByEmailSubscriptionUseCase {
+    private final SubscriptionQueryRepository subscriptionQueryRepository;
+    private final SubscriptionFactory subscriptionFactory;
+
+    @Override
+    public SubscriptionResponse getByEmail(String email) {
+        return subscriptionQueryRepository.findByCustomerEmail(email)
+            .map(subscriptionFactory::createFromEntity)
+            .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not found for email: " + email));
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetByIdSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetByIdSubscriptionUseCaseService.java
@@ -1,0 +1,28 @@
+package com.jame.dev.gymApp.features.subscription.application.service.query;
+
+import com.jame.dev.gymApp.application.model.CacheValues;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByIdSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetByIdSubscriptionUseCaseService implements GetByIdSubscriptionUseCase {
+    private final SubscriptionQueryRepository subscriptionQueryRepository;
+    private final SubscriptionFactory subscriptionFactory;
+
+    @Override
+    @Cacheable(value = CacheValues.SUBSCRIPTION, key = "#id")
+    public SubscriptionResponse getById(long id) {
+        return subscriptionQueryRepository.findById(id)
+            .map(subscriptionFactory::createFromEntity)
+            .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not found."));
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetPageSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetPageSubscriptionUseCaseService.java
@@ -1,0 +1,40 @@
+package com.jame.dev.gymApp.features.subscription.application.service.query;
+
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.application.model.CacheValues;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetPageSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.specification.SubscriptionSpecification;
+import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetPageSubscriptionUseCaseService implements GetPageSubscriptionUseCase {
+    private final SubscriptionQueryRepository subscriptionQueryRepository;
+    private final SubscriptionFactory subscriptionFactory;
+    private final SortPropertyResolver subSortAppResolver;
+
+    @Override
+    @Cacheable(
+        value = CacheValues.SUBSCRIPTIONS,
+        keyGenerator = "pageKeyGenerator",
+        unless = "#result == null || #result.content.isEmpty()"
+    )
+    public PageDto<SubscriptionResponse> getPage(Pageable pageable, String search) {
+        final Pageable pageableWrapped = subSortAppResolver.resolve(pageable);
+        final Specification<SubscriptionEntity> spec = new SubscriptionSpecification(search);
+        final Page<SubscriptionEntity> entityPage = subscriptionQueryRepository.findAll(spec, pageableWrapped);
+        return subscriptionFactory.createPageFrom(entityPage);
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/validation/ExistsByIdAndCustomerEmailUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/validation/ExistsByIdAndCustomerEmailUseCaseService.java
@@ -1,0 +1,19 @@
+package com.jame.dev.gymApp.features.subscription.application.service.validation;
+
+import com.jame.dev.gymApp.features.subscription.application.usecases.validation.ExistsByIdAndCustomerEmailUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionValidationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExistsByIdAndCustomerEmailUseCaseService implements ExistsByIdAndCustomerEmailUseCase {
+    private final SubscriptionValidationRepository subscriptionValidationRepository;
+
+    @Override
+    public boolean existsByIdAndCustomerEmail(long id, String email) {
+        return subscriptionValidationRepository.existsByIdAndCustomerEmail(id, email);
+    }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/validator/SubscriptionValidator.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/validator/SubscriptionValidator.java
@@ -9,7 +9,7 @@ import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
 import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
-import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/CreateSubscriptionUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/CreateSubscriptionUseCase.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+
+public interface CreateSubscriptionUseCase {
+    SubscriptionResponse create(final SubscriptionRequest request);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/FinalizeSubscriptionUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/FinalizeSubscriptionUseCase.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+
+public interface FinalizeSubscriptionUseCase {
+    SubscriptionResponse finalize(final long id);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/RenewSubscriptionUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/RenewSubscriptionUseCase.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+
+public interface RenewSubscriptionUseCase {
+    SubscriptionResponse renew(final long id, final SubscriptionRequest input);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/SoftDeleteSubscriptionByIdUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/SoftDeleteSubscriptionByIdUseCase.java
@@ -1,0 +1,5 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.mutation;
+
+public interface SoftDeleteSubscriptionByIdUseCase {
+    void softDeleteById(final long id);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/UpdateSubscriptionUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/mutation/UpdateSubscriptionUseCase.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+
+public interface UpdateSubscriptionUseCase {
+    SubscriptionResponse update(final long id, final SubscriptionRequest request);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetByEmailSubscriptionUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetByEmailSubscriptionUseCase.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.query;
+
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+
+public interface GetByEmailSubscriptionUseCase {
+    SubscriptionResponse getByEmail(final String email);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetByIdSubscriptionUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetByIdSubscriptionUseCase.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.query;
+
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+
+public interface GetByIdSubscriptionUseCase {
+    SubscriptionResponse getById(final long id);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetPageSubscriptionUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetPageSubscriptionUseCase.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.query;
+
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface GetPageSubscriptionUseCase {
+    PageDto<SubscriptionResponse> getPage(final Pageable pageable, final String search);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/validation/ExistsByIdAndCustomerEmailUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/validation/ExistsByIdAndCustomerEmailUseCase.java
@@ -1,0 +1,5 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.validation;
+
+public interface ExistsByIdAndCustomerEmailUseCase {
+    boolean existsByIdAndCustomerEmail(final long id, final String email);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/SubscriptionMutationRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/SubscriptionMutationRepository.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.subscription.domain.repository;
+
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+
+public interface SubscriptionMutationRepository {
+
+   SubscriptionEntity save(final SubscriptionEntity subscriptionEntity);
+
+   void deleteById(long id);
+
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/SubscriptionQueryRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/SubscriptionQueryRepository.java
@@ -1,0 +1,21 @@
+package com.jame.dev.gymApp.features.subscription.domain.repository;
+
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SubscriptionQueryRepository {
+
+   List<SubscriptionEntity> findAll();
+
+   Page<SubscriptionEntity> findAll(final Specification<SubscriptionEntity> specification, final Pageable pageable);
+
+   Optional<SubscriptionEntity> findById(final long id);
+
+   Optional<SubscriptionEntity> findByCustomerEmail(final String email);
+
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/SubscriptionValidationRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/SubscriptionValidationRepository.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.features.subscription.domain.repository;
+
+import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
+
+public interface SubscriptionValidationRepository {
+
+   boolean existsById(final long id);
+
+   boolean existsByIdAndCustomerEmail(final long subscriptionId, final String email);
+
+   boolean existsByCustomer(final CustomerEntity customerEntity);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/SubscriptionMutationJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/SubscriptionMutationJpaRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.jame.dev.gymApp.features.subscription.infrastructure.adapter;
+
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriptionMutationJpaRepositoryAdapter implements SubscriptionMutationRepository {
+   private final SubscriptionRepository subscriptionRepository;
+
+   @Override
+   public SubscriptionEntity save(SubscriptionEntity subscriptionEntity) {
+      return subscriptionRepository.saveAndFlush(subscriptionEntity);
+   }
+
+   @Override
+   public void deleteById(long id) {
+      subscriptionRepository.deleteById(id);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/SubscriptionQueryJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/SubscriptionQueryJpaRepositoryAdapter.java
@@ -1,0 +1,39 @@
+package com.jame.dev.gymApp.features.subscription.infrastructure.adapter;
+
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriptionQueryJpaRepositoryAdapter implements SubscriptionQueryRepository {
+   private final SubscriptionRepository subscriptionRepository;
+
+   @Override
+   public List<SubscriptionEntity> findAll() {
+      return subscriptionRepository.findAll();
+   }
+
+   @Override
+   public Page<SubscriptionEntity> findAll(Specification<SubscriptionEntity> specification, Pageable pageable) {
+      return subscriptionRepository.findAll(specification, pageable);
+   }
+
+   @Override
+   public Optional<SubscriptionEntity> findById(long id) {
+      return subscriptionRepository.findById(id);
+   }
+
+   @Override
+   public Optional<SubscriptionEntity> findByCustomerEmail(String email) {
+      return subscriptionRepository.findByCustomerEmail(email);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/SubscriptionValidationJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/SubscriptionValidationJpaRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.jame.dev.gymApp.features.subscription.infrastructure.adapter;
+
+import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionValidationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriptionValidationJpaRepositoryAdapter implements SubscriptionValidationRepository {
+   private final SubscriptionRepository subscriptionRepository;
+
+   @Override
+   public boolean existsById(long id) {
+      return subscriptionRepository.existsById(id);
+   }
+
+   @Override
+   public boolean existsByIdAndCustomerEmail(long subscriptionId, String email) {
+      return subscriptionRepository.existsByIdAndCustomer_User_Email(subscriptionId, email);
+   }
+
+   @Override
+   public boolean existsByCustomer(CustomerEntity customerEntity) {
+      return subscriptionRepository.existsByCustomer(customerEntity);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/notification/service/SubscriptionNotificationAppService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/notification/service/SubscriptionNotificationAppService.java
@@ -4,7 +4,7 @@ import com.jame.dev.gymApp.features.notification.application.contract.EmailServi
 import com.jame.dev.gymApp.features.notification.application.dto.EmailDetails;
 import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
 import com.jame.dev.gymApp.features.subscription.domain.model.PeriodEntity;
-import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
 import com.jame.dev.gymApp.features.subscription.infrastructure.notification.model.NotifiableSubscription;
 import com.jame.dev.gymApp.features.subscription.infrastructure.notification.template.HTMLSubscriptionPeriodTemplate;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/MembershipRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/MembershipRepository.java
@@ -1,4 +1,4 @@
-package com.jame.dev.gymApp.features.subscription.domain.repository;
+package com.jame.dev.gymApp.features.subscription.infrastructure.persistence;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.MemberShipEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PeriodRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PeriodRepository.java
@@ -1,4 +1,4 @@
-package com.jame.dev.gymApp.features.subscription.domain.repository;
+package com.jame.dev.gymApp.features.subscription.infrastructure.persistence;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.PeriodEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.Period;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PricingRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PricingRepository.java
@@ -1,4 +1,4 @@
-package com.jame.dev.gymApp.features.subscription.domain.repository;
+package com.jame.dev.gymApp.features.subscription.infrastructure.persistence;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/SubscriptionRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/SubscriptionRepository.java
@@ -1,4 +1,4 @@
-package com.jame.dev.gymApp.features.subscription.domain.repository;
+package com.jame.dev.gymApp.features.subscription.infrastructure.persistence;
 
 import com.jame.dev.gymApp.domain.repository.CustomJpaRepository;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.NativeQuery;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface SubscriptionRepository extends CustomJpaRepository<SubscriptionEntity, Long> {
@@ -18,21 +17,11 @@ public interface SubscriptionRepository extends CustomJpaRepository<Subscription
       JOIN FETCH c.user u
       WHERE u.email = :email AND s.active = true
       """)
-   Optional<SubscriptionEntity> findActiveSubscriptionByEmail(@Param("email") @NonNull final String email);
+   Optional<SubscriptionEntity> findByCustomerEmail(@Param("email") @NonNull final String email);
 
-   boolean existsByIdAndCustomer_User_EmailAndActiveTrue(long id, String email);
+   boolean existsByIdAndCustomer_User_Email(long id, String email);
 
    boolean existsByCustomer(final CustomerEntity customer);
-
-   void deleteByCustomerId(long id);
-
-   @Query(
-      """
-         SELECT s
-         FROM SubscriptionEntity s
-         JOIN FETCH s.subscriptionPeriods
-         """)
-   List<SubscriptionEntity> findAllNotifiable();
 
    @NativeQuery("""
       SELECT * FROM subscriptions s

--- a/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
@@ -8,7 +8,7 @@ import com.jame.dev.gymApp.features.customer.infrastructure.persistence.Customer
 import com.jame.dev.gymApp.features.subscription.application.contract.MembershipService;
 import com.jame.dev.gymApp.features.subscription.application.contract.PricingService;
 import com.jame.dev.gymApp.features.subscription.domain.model.*;
-import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
 import com.jame.dev.gymApp.features.user.application.contract.UserFactory;
 import com.jame.dev.gymApp.features.user.domain.model.Role;

--- a/src/test/java/com/jame/dev/gymApp/service/MembershipServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/MembershipServiceTest.java
@@ -1,7 +1,7 @@
 package com.jame.dev.gymApp.service;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.MemberShipEntity;
-import com.jame.dev.gymApp.features.subscription.domain.repository.MembershipRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.MembershipRepository;
 import com.jame.dev.gymApp.features.subscription.application.service.MembershipApplicationService;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/jame/dev/gymApp/service/PricingServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/PricingServiceTest.java
@@ -2,7 +2,7 @@ package com.jame.dev.gymApp.service;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.MemberShipEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
-import com.jame.dev.gymApp.features.subscription.domain.repository.PricingRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
 import com.jame.dev.gymApp.features.subscription.application.service.PricingApplicationService;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/jame/dev/gymApp/service/SubscriptionServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/service/SubscriptionServiceTest.java
@@ -14,8 +14,8 @@ import com.jame.dev.gymApp.features.subscription.application.dto.SubscriptionFac
 import com.jame.dev.gymApp.application.dto.PageDto;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.customer.infrastructure.persistence.CustomerRepository;
-import com.jame.dev.gymApp.features.subscription.domain.repository.PricingRepository;
-import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
 import com.jame.dev.gymApp.features.subscription.application.service.SubscriptionApplicationService;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionUpdater;
@@ -43,6 +43,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * @deprecated Use cases extracted to {@code subscription/usecases/{query,mutation,validation}/}.
+ * Each use case now has its own dedicated test under the corresponding package.
+ */
+@Deprecated(forRemoval = true)
 @ExtendWith(MockitoExtension.class)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 class SubscriptionServiceTest {

--- a/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionAdministrationControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionAdministrationControllerTest.java
@@ -1,0 +1,603 @@
+package com.jame.dev.gymApp.subscription.controller;
+
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.domain.exception.MissMatchException;
+import com.jame.dev.gymApp.domain.exception.NoActiveException;
+import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException;
+import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
+import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthorizationFilter;
+import com.jame.dev.gymApp.features.customer.api.response.CustomerResponse;
+import com.jame.dev.gymApp.features.subscription.api.SubscriptionAdministrationController;
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.dto.PeriodDtoOutput;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.FinalizeSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.RenewSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.SoftDeleteSubscriptionByIdUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.UpdateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByIdSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetPageSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.RenewSubscriptionException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionUnfinishedException;
+import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
+import com.jame.dev.gymApp.features.subscription.domain.model.Period;
+import com.jame.dev.gymApp.features.subscription.infrastructure.notification.service.SubscriptionNotificationAppService;
+import com.jame.dev.gymApp.features.user.api.response.UserResponse;
+import com.jame.dev.gymApp.features.user.domain.model.Role;
+import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
+import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
+import config.TestConfig;
+import config.TestDataSource;
+import config.TestValidationConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+   controllers = SubscriptionAdministrationController.class,
+   excludeFilters = {
+      @ComponentScan.Filter(
+         type = FilterType.ASSIGNABLE_TYPE,
+         classes = CustomAuthorizationFilter.class
+      )}
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({
+   GlobalExceptionHandler.class,
+   TestValidationConfig.class,
+   TestConfig.class})
+@ImportAutoConfiguration({ValidationAutoConfiguration.class})
+class SubscriptionAdministrationControllerTest {
+
+   @Autowired
+   private MockMvc mockMvc;
+
+   @Autowired
+   private SubscriptionAdministrationController controller;
+
+   @Autowired
+   private ApiErrorResponseFactory responseFactory;
+
+   @MockitoBean
+   private GetPageSubscriptionUseCase subscriptionGetPage;
+
+   @MockitoBean
+   private GetByIdSubscriptionUseCase subscriptionGetById;
+
+   @MockitoBean
+   private CreateSubscriptionUseCase subscriptionCreate;
+
+   @MockitoBean
+   private UpdateSubscriptionUseCase subscriptionUpdate;
+
+   @MockitoBean
+   private RenewSubscriptionUseCase subscriptionRenew;
+
+   @MockitoBean
+   private FinalizeSubscriptionUseCase subscriptionFinalize;
+
+   @MockitoBean
+   private SoftDeleteSubscriptionByIdUseCase subscriptionSoftDelete;
+
+   @MockitoBean
+   private SubscriptionNotificationAppService subsNotificationAppService;
+
+   private final String URI_TEMPLATE = "/app/v1/administration/subs";
+   private final CustomerResponse customerResponse = new CustomerResponse(
+      1L, new UserResponse(1L, "dto", "dto@mail", AuthProvider.LOCAL, Set.of(Role.USER)), "25082525"
+   );
+
+   private final SubscriptionResponse subscriptionResponse = new SubscriptionResponse(
+      1L, customerResponse,
+      Membership.ANNUAL, BigDecimal.valueOf(3000d),
+      List.of(new PeriodDtoOutput(1L, Period.ANNUAL, LocalDate.now(), LocalDate.now().plusYears(1))),
+      false
+   );
+
+   @Nested
+   @DisplayName("GET Subscription Resources.")
+   class SubscriptionAdministrationControllerGetResourceTests {
+
+      @Test
+      @DisplayName("GET[200] OK: get page /subs?page=0&size=1")
+      void getPage() throws Exception {
+         PageDto<SubscriptionResponse> page = mock();
+         given(page.content()).willReturn(List.of());
+         given(page.totalElements()).willReturn(0L);
+      given(subscriptionGetPage.getPage(any(), any())).willReturn(page);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE)
+               .param("page", "0")
+               .param("size", "1")
+               .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content").exists());
+         verify(subscriptionGetPage, times(1)).getPage(any(), any());
+      }
+
+      @Test
+      @DisplayName("GET[200] OK: get sub /subs/{id}")
+      void getSubscription() throws Exception {
+         given(subscriptionGetById.getById(anyLong())).willReturn(subscriptionResponse);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionGetById, times(1)).getById(anyLong());
+      }
+
+      @Test
+      @DisplayName("GET[404] Not Found: get sub /subs/{id}")
+      void subscriptionNotFound() throws Exception {
+         given(subscriptionGetById.getById(anyLong())).willThrow(SubscriptionNotFoundException.class);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 100L)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionGetById, times(1)).getById(anyLong());
+         verifyNoMoreInteractions(subscriptionGetById);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("GET[400] Bad Request: get sub /subs/{invalidPath}")
+      void badRequestInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionGetById);
+      }
+   }
+
+   @Nested
+   @DisplayName("POST Subscription Resources.")
+   class SubscriptionAdministrationControllerPostResourceTests {
+
+      private final String payload = """
+         {
+            "customerEmail": "user@mail.com",
+            "membership": "ANNUAL"
+         }
+         """;
+
+      @Test
+      @DisplayName("POST[201] Created")
+      void postSubscription() throws Exception {
+         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.id").isNotEmpty());
+         verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
+      }
+
+      @Test
+      @DisplayName("POST[409]: Conflict: Subscription already exists")
+      void subscriptionAlreadyExists() throws Exception {
+         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willThrow(AlreadyExistsException.class);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(409))
+            .andExpect(jsonPath("$.code").value("SAVE_OPERATION"));
+         verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
+      }
+
+      @Test
+      @DisplayName("POST[409]: Conflict: Subscription is deactivated")
+      void subscriptionIsDeactivated() throws Exception {
+         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willThrow(NoActiveException.class);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(409))
+            .andExpect(jsonPath("$.code").value("VALIDATION_OPERATION"));
+         verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.SUBSCRIPTION_FORMAT_PAYLOAD_ERROR,
+         nullValues = "NULL", emptyValue = "EMPTY")
+      @DisplayName("POST[400]: Bad Request: Invalid values inside payload.")
+      void badRequestInvalidPayloadValues(String email, String membership, String codeExpected) throws Exception {
+         String payload = """
+            {
+               "customerEmail": "%s",
+               "membership": "%s"
+            }
+            """.formatted(email, membership);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionCreate);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         nullValues = "NULL",
+         emptyValue = "EMPTY",
+         textBlock = TestDataSource.BODY_FORMAT_ERRORS)
+      @DisplayName("POST[400]: Bad Request: Invalid payload")
+      void badRequestInvalidPayload(String value, String codeExpected) throws Exception {
+         mockMvc.perform(
+               post(URI_TEMPLATE)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(value)
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionCreate);
+      }
+   }
+
+   @Nested
+   @DisplayName("POST Notify Subscription.")
+   class SubscriptionAdministrationControllerPostNotify {
+
+      @Test
+      @DisplayName("POST[200] OK: notify subscribers")
+      void notifySubscribers() throws Exception {
+         mockMvc.perform(post(URI_TEMPLATE + "/notify"))
+            .andExpect(status().isOk());
+         verify(subsNotificationAppService, times(1)).notifySubscriptionEnds();
+         verifyNoMoreInteractions(subsNotificationAppService);
+      }
+   }
+
+   @Nested
+   @DisplayName("PUT Subscription Resources.")
+   class SubscriptionAdministrationControllerPutResources {
+      String payload = """
+         {
+          "customerEmail": "user@mail.com",
+          "membership": "ANNUAL"
+         }
+         """;
+
+      @Test
+      @DisplayName("PUT[200] OK: Editing subscription info.")
+      void putSubscription() throws Exception {
+         given(subscriptionUpdate.update(anyLong(), any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionUpdate, times(1)).update(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @Test
+      @DisplayName("PUT[404] Not Found")
+      void subscriptionNotFound() throws Exception {
+         given(subscriptionUpdate.update(anyLong(), any(SubscriptionRequest.class))).willThrow(SubscriptionNotFoundException.class);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(404));
+         verify(subscriptionUpdate, times(1)).update(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("PUT[400] Bad Request: invalid id format")
+      void invalidId(String value, String expectedCode) throws Exception {
+         mockMvc.perform(MockMvcRequestBuilders.put(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionUpdate);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.SUBSCRIPTION_FORMAT_PAYLOAD_ERROR,
+         nullValues = "NULL", emptyValue = "EMPTY")
+      @DisplayName("PUT[400]: Bad Request: Invalid values inside payload.")
+      void badRequestInvalidPayloadValues(String email, String membership, String codeExpected) throws Exception {
+         String payload = """
+            {
+               "customerEmail": "%s",
+               "membership": "%s"
+            }
+            """.formatted(email, membership);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionUpdate);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         nullValues = "NULL",
+         emptyValue = "EMPTY",
+         textBlock = TestDataSource.BODY_FORMAT_ERRORS)
+      @DisplayName("PUT[400]: Bad Request: Invalid payload")
+      void badRequestInvalidPayload(String value, String codeExpected) throws Exception {
+         mockMvc.perform(
+               put(URI_TEMPLATE + '/' + 1L)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(value)
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionUpdate);
+      }
+   }
+
+   @Nested
+   @DisplayName("PUT Subscription Renew.")
+   class SubscriptionAdministrationControllerPutRenew {
+      String payload = """
+         {
+          "customerEmail": "user@mail.com",
+          "membership": "ANNUAL"
+         }
+         """;
+
+      static Stream<Arguments> renewExceptions() {
+         int[] codes = {409, 404};
+         return Stream.of(
+            Arguments.of(SubscriptionUnfinishedException.class, codes[0]),
+            Arguments.of(MissMatchException.class, codes[0]),
+            Arguments.of(RenewSubscriptionException.class, codes[0]),
+            Arguments.of(PricingNotFoundException.class, codes[1])
+         );
+      }
+
+      @Test
+      @DisplayName("PUT[200] Ok: Renew Subscription /subs/{id}/renew")
+      void renewSubscription() throws Exception {
+         given(subscriptionRenew.renew(anyLong(), any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L + "/renew")
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionRenew, times(1)).renew(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @Test
+      @DisplayName("PUT[409] Conflict: Subscription active")
+      void subscriptionActive() throws Exception {
+         given(subscriptionRenew.renew(anyLong(), any(SubscriptionRequest.class))).willThrow(SubscriptionUnfinishedException.class);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L + "/renew")
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(409));
+         verify(subscriptionRenew, times(1)).renew(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @ParameterizedTest
+      @MethodSource("renewExceptions")
+      @DisplayName("PUT[409 | 404]: Cannot renew.")
+      void renewNotAllowed(Class<? extends Throwable> exception, int code) throws Exception {
+         given(subscriptionRenew.renew(anyLong(), any(SubscriptionRequest.class))).willThrow(exception);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L + "/renew")
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().is(code))
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(code));
+         verify(subscriptionRenew, atLeastOnce()).renew(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("PUT[400] Bad Request: renew - invalid id format")
+      void invalidId(String value, String expectedCode) throws Exception {
+         mockMvc.perform(MockMvcRequestBuilders.put(URI_TEMPLATE + '/' + value + "/renew")
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionRenew);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.SUBSCRIPTION_FORMAT_PAYLOAD_ERROR,
+         nullValues = "NULL", emptyValue = "EMPTY")
+      @DisplayName("PUT[400]: Bad Request: renew - Invalid values inside payload.")
+      void badRequestInvalidPayloadValues(String email, String membership, String codeExpected) throws Exception {
+         String payload = """
+            {
+               "customerEmail": "%s",
+               "membership": "%s"
+            }
+            """.formatted(email, membership);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L + "/renew")
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionRenew);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         nullValues = "NULL",
+         emptyValue = "EMPTY",
+         textBlock = TestDataSource.BODY_FORMAT_ERRORS)
+      @DisplayName("PUT[400]: Bad Request: renew - Invalid payload")
+      void badRequestInvalidPayload(String value, String codeExpected) throws Exception {
+         mockMvc.perform(
+               put(URI_TEMPLATE + '/' + 1L + "/renew")
+                  .accept(MediaType.APPLICATION_JSON)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(value)
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionRenew);
+      }
+   }
+
+   @Nested
+   @DisplayName("PATCH")
+   class SubscriptionAdministrationControllerPatchFinalize {
+      @Test
+      @DisplayName("PATCH[200] OK: Subscription finalized")
+      void finalizeSubscription() throws Exception {
+         SubscriptionResponse finalized = new SubscriptionResponse(
+            1L, customerResponse,
+            subscriptionResponse.membership(),
+            subscriptionResponse.price(),
+            subscriptionResponse.periods(),
+            true
+         );
+         given(subscriptionFinalize.finalize(anyLong())).willReturn(finalized);
+         mockMvc.perform(patch(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionFinalize, times(1)).finalize(anyLong());
+      }
+
+      @Test
+      @DisplayName("PATCH[404] Not Found: Subscription not found")
+      void subscriptionNotFound() throws Exception {
+         given(subscriptionFinalize.finalize(anyLong())).willThrow(SubscriptionNotFoundException.class);
+         mockMvc.perform(patch(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionFinalize, times(1)).finalize(anyLong());
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("PATCH[400] Bad Request: invalid id format")
+      void badRequestInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(patch(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionFinalize);
+      }
+   }
+
+   @Nested
+   @DisplayName("DELETE Subscription Resources.")
+   class SubscriptionAdministrationControllerDeleteResources {
+
+      @Test
+      @DisplayName("DELETE[204] No Content: Subscription Deleted")
+      void deleteSubscription() throws Exception {
+         mockMvc.perform(delete(URI_TEMPLATE + '/' + 1L))
+            .andExpect(status().isNoContent())
+            .andExpect(jsonPath("$.*").doesNotExist());
+         verify(subscriptionSoftDelete, times(1)).softDeleteById(anyLong());
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("DELETE[400] Bad Request: get subscription /subs/{invalidPath}")
+      void badRequestInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(delete(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionSoftDelete);
+      }
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionUserControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionUserControllerTest.java
@@ -1,0 +1,479 @@
+package com.jame.dev.gymApp.subscription.controller;
+
+import com.jame.dev.gymApp.domain.exception.MissMatchException;
+import com.jame.dev.gymApp.domain.exception.NoActiveException;
+import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException;
+import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
+import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthorizationFilter;
+import com.jame.dev.gymApp.features.customer.api.response.CustomerResponse;
+import com.jame.dev.gymApp.features.subscription.api.SubscriptionUserController;
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.dto.PeriodDtoOutput;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.FinalizeSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.RenewSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.UpdateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByEmailSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByIdSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.RenewSubscriptionException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionUnfinishedException;
+import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
+import com.jame.dev.gymApp.features.subscription.domain.model.Period;
+import com.jame.dev.gymApp.features.user.api.response.UserResponse;
+import com.jame.dev.gymApp.features.user.domain.model.Role;
+import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
+import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
+import config.TestConfig;
+import config.TestDataSource;
+import config.TestValidationConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+   controllers = SubscriptionUserController.class,
+   excludeFilters = {
+      @ComponentScan.Filter(
+         type = FilterType.ASSIGNABLE_TYPE,
+         classes = CustomAuthorizationFilter.class
+      )}
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({
+   GlobalExceptionHandler.class,
+   TestValidationConfig.class,
+   TestConfig.class})
+@ImportAutoConfiguration({ValidationAutoConfiguration.class})
+class SubscriptionUserControllerTest {
+
+   @Autowired
+   private MockMvc mockMvc;
+
+   @Autowired
+   private SubscriptionUserController controller;
+
+   @Autowired
+   private ApiErrorResponseFactory responseFactory;
+
+   @MockitoBean
+   private GetByIdSubscriptionUseCase subscriptionGetById;
+
+   @MockitoBean
+   private GetByEmailSubscriptionUseCase subscriptionGetByEmail;
+
+   @MockitoBean
+   private CreateSubscriptionUseCase subscriptionCreate;
+
+   @MockitoBean
+   private UpdateSubscriptionUseCase subscriptionUpdate;
+
+   @MockitoBean
+   private RenewSubscriptionUseCase subscriptionRenew;
+
+   @MockitoBean
+   private FinalizeSubscriptionUseCase subscriptionFinalize;
+
+   private final String URI_TEMPLATE = "/app/v1/subscriptions";
+   private final CustomerResponse customerResponse = new CustomerResponse(
+      1L, new UserResponse(1L, "dto", "dto@mail", AuthProvider.LOCAL, Set.of(Role.USER)), "25082525"
+   );
+
+   private final SubscriptionResponse subscriptionResponse = new SubscriptionResponse(
+      1L, customerResponse,
+      Membership.ANNUAL, BigDecimal.valueOf(3000d),
+      List.of(new PeriodDtoOutput(1L, Period.ANNUAL, LocalDate.now(), LocalDate.now().plusYears(1))),
+      false
+   );
+
+   @Nested
+   @DisplayName("GET Subscription Resources.")
+   class SubscriptionUserControllerGetResourceTests {
+
+      @Test
+      @DisplayName("GET[200] OK: get subscription /subscriptions/{id}")
+      void getById() throws Exception {
+         given(subscriptionGetById.getById(anyLong())).willReturn(subscriptionResponse);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionGetById, times(1)).getById(anyLong());
+      }
+
+      @Test
+      @DisplayName("GET[404] Not Found: get subscription /subscriptions/{id}")
+      void subscriptionNotFound() throws Exception {
+         given(subscriptionGetById.getById(anyLong())).willThrow(SubscriptionNotFoundException.class);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + 100L)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionGetById, times(1)).getById(anyLong());
+         verifyNoMoreInteractions(subscriptionGetById);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("GET[400] Bad Request: get subscription /subscriptions/{invalidPath}")
+      void badRequestInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionGetById);
+      }
+
+      @Test
+      @DisplayName("GET[200] OK: get subscription by email /subscriptions/{email}/customers")
+      void getByEmail() throws Exception {
+         given(subscriptionGetByEmail.getByEmail(anyString())).willReturn(subscriptionResponse);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + "/user@mail.com/customers")
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionGetByEmail, times(1)).getByEmail(anyString());
+      }
+
+      @Test
+      @DisplayName("GET[404] Not Found: get subscription by email /subscriptions/{email}/customers")
+      void subscriptionNotFoundByEmail() throws Exception {
+         given(subscriptionGetByEmail.getByEmail(anyString())).willThrow(SubscriptionNotFoundException.class);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + "/missing@mail.com/customers")
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionGetByEmail, times(1)).getByEmail(anyString());
+         verifyNoMoreInteractions(subscriptionGetByEmail);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         nullValues = "NULL",
+         textBlock = """
+            EMAIL,              ERROR_CODE
+            not-an-email,       CONSTRAINT_OPERATION
+            EMPTY,              CONSTRAINT_OPERATION
+            NULL,               CONSTRAINT_OPERATION
+            """)
+      @DisplayName("GET[400] Bad Request: get subscription by email /subscriptions/{invalidEmail}/customers")
+      void badRequestInvalidEmailPathVariable(String email, String expectedCode) throws Exception {
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + "/" + email + "/customers")
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionGetByEmail);
+      }
+   }
+
+   @Nested
+   @DisplayName("POST Subscription Resources.")
+   class SubscriptionUserControllerPostResourceTests {
+
+      private final String payload = """
+         {
+            "customerEmail": "user@mail.com",
+            "membership": "ANNUAL"
+         }
+         """;
+
+      @Test
+      @DisplayName("POST[201] Created")
+      void create() throws Exception {
+         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.id").isNotEmpty());
+         verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
+      }
+
+      @Test
+      @DisplayName("POST[409]: Conflict: Subscription already exists")
+      void alreadyExists() throws Exception {
+         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willThrow(AlreadyExistsException.class);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(409))
+            .andExpect(jsonPath("$.code").value("SAVE_OPERATION"));
+         verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
+      }
+
+      @Test
+      @DisplayName("POST[409]: Conflict: Subscription is deactivated")
+      void subscriptionIsDeactivated() throws Exception {
+         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willThrow(NoActiveException.class);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(409))
+            .andExpect(jsonPath("$.code").value("VALIDATION_OPERATION"));
+         verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.SUBSCRIPTION_FORMAT_PAYLOAD_ERROR,
+         nullValues = "NULL", emptyValue = "EMPTY")
+      @DisplayName("POST[400]: Bad Request: Invalid values inside payload.")
+      void badRequestInvalidPayloadValues(String email, String membership, String codeExpected) throws Exception {
+         String payload = """
+            {
+               "customerEmail": "%s",
+               "membership": "%s"
+            }
+            """.formatted(email, membership);
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionCreate);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         nullValues = "NULL",
+         emptyValue = "EMPTY",
+         textBlock = TestDataSource.BODY_FORMAT_ERRORS)
+      @DisplayName("POST[400]: Bad Request: Invalid payload")
+      void badRequestInvalidPayload(String value, String codeExpected) throws Exception {
+         mockMvc.perform(
+               post(URI_TEMPLATE)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(value)
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionCreate);
+      }
+   }
+
+   @Nested
+   @DisplayName("PUT Subscription Renew.")
+   class SubscriptionUserControllerPutRenew {
+      String payload = """
+         {
+          "customerEmail": "user@mail.com",
+          "membership": "ANNUAL"
+         }
+         """;
+
+      static Stream<Arguments> renewExceptions() {
+         int[] codes = {409, 404};
+         return Stream.of(
+            Arguments.of(SubscriptionUnfinishedException.class, codes[0]),
+            Arguments.of(MissMatchException.class, codes[0]),
+            Arguments.of(RenewSubscriptionException.class, codes[0]),
+            Arguments.of(PricingNotFoundException.class, codes[1])
+         );
+      }
+
+      @Test
+      @DisplayName("PUT[200] Ok: Renew Subscription /subscriptions/{id}")
+      void renew() throws Exception {
+         given(subscriptionRenew.renew(anyLong(), any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionRenew, times(1)).renew(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @Test
+      @DisplayName("PUT[409] Conflict: Subscription active")
+      void subscriptionActive() throws Exception {
+         given(subscriptionRenew.renew(anyLong(), any(SubscriptionRequest.class))).willThrow(SubscriptionUnfinishedException.class);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(409));
+         verify(subscriptionRenew, times(1)).renew(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @ParameterizedTest
+      @MethodSource("renewExceptions")
+      @DisplayName("PUT[409 | 404]: Cannot renew.")
+      void renewNotAllowed(Class<? extends Throwable> exception, int code) throws Exception {
+         given(subscriptionRenew.renew(anyLong(), any(SubscriptionRequest.class))).willThrow(exception);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().is(code))
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(code));
+         verify(subscriptionRenew, atLeastOnce()).renew(anyLong(), any(SubscriptionRequest.class));
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("PUT[400] Bad Request: renew - invalid id format")
+      void invalidId(String value, String expectedCode) throws Exception {
+         mockMvc.perform(MockMvcRequestBuilders.put(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionRenew);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.SUBSCRIPTION_FORMAT_PAYLOAD_ERROR,
+         nullValues = "NULL", emptyValue = "EMPTY")
+      @DisplayName("PUT[400]: Bad Request: renew - Invalid values inside payload.")
+      void badRequestInvalidPayloadValues(String email, String membership, String codeExpected) throws Exception {
+         String payload = """
+            {
+               "customerEmail": "%s",
+               "membership": "%s"
+            }
+            """.formatted(email, membership);
+         mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionRenew);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         nullValues = "NULL",
+         emptyValue = "EMPTY",
+         textBlock = TestDataSource.BODY_FORMAT_ERRORS)
+      @DisplayName("PUT[400]: Bad Request: renew - Invalid payload")
+      void badRequestInvalidPayload(String value, String codeExpected) throws Exception {
+         mockMvc.perform(
+               put(URI_TEMPLATE + '/' + 1L)
+                  .accept(MediaType.APPLICATION_JSON)
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(value)
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+         verifyNoInteractions(subscriptionRenew);
+      }
+   }
+
+   @Nested
+   @DisplayName("PATCH")
+   class SubscriptionUserControllerPatchFinalize {
+      @Test
+      @DisplayName("PATCH[200] OK: Subscription finalized")
+      void finalizeSubscription() throws Exception {
+         SubscriptionResponse finalized = new SubscriptionResponse(
+            1L, customerResponse,
+            subscriptionResponse.membership(),
+            subscriptionResponse.price(),
+            subscriptionResponse.periods(),
+            true
+         );
+         given(subscriptionFinalize.finalize(anyLong())).willReturn(finalized);
+         mockMvc.perform(patch(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionFinalize, times(1)).finalize(anyLong());
+      }
+
+      @Test
+      @DisplayName("PATCH[404] Not Found: Subscription not found")
+      void subscriptionNotFound() throws Exception {
+         given(subscriptionFinalize.finalize(anyLong())).willThrow(SubscriptionNotFoundException.class);
+         mockMvc.perform(patch(URI_TEMPLATE + '/' + 1L)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists());
+         verify(subscriptionFinalize, times(1)).finalize(anyLong());
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("PATCH[400] Bad Request: invalid id format")
+      void badRequestInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(patch(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON)
+               .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(subscriptionFinalize);
+      }
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/CreateSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/CreateSubscriptionUseCaseServiceTest.java
@@ -1,0 +1,125 @@
+package com.jame.dev.gymApp.subscription.usecases.mutation;
+
+import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException;
+import com.jame.dev.gymApp.features.customer.domain.exception.CustomerNotFoundException;
+import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
+import com.jame.dev.gymApp.features.customer.domain.repository.CustomerQueryRepository;
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.dto.SubscriptionFactoryDtoInput;
+import com.jame.dev.gymApp.features.subscription.application.service.mutation.CreateSubscriptionUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
+import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionValidationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateSubscriptionUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionMutationRepository subscriptionMutationRepository;
+
+    @Mock
+    private CustomerQueryRepository customerQueryRepository;
+
+    @Mock
+    private PricingRepository pricingRepository;
+
+    @Mock
+    private SubscriptionValidationRepository subscriptionValidationRepository;
+
+    @Mock
+    private SubscriptionFactory subscriptionFactory;
+
+    @InjectMocks
+    private CreateSubscriptionUseCaseService service;
+
+    private final SubscriptionRequest request = new SubscriptionRequest("customer@mail.com", Membership.MONTHLY);
+
+    @Test
+    @DisplayName("Should create and return SubscriptionResponse when all validations pass")
+    void create_createsAndReturnsResponse() {
+        var customer = mock(CustomerEntity.class);
+        var pricing = mock(PricingEntity.class);
+        var entity = mock(SubscriptionEntity.class);
+        var savedEntity = mock(SubscriptionEntity.class);
+        var response = mock(SubscriptionResponse.class);
+
+        given(customerQueryRepository.findByUserEmail(anyString())).willReturn(Optional.of(customer));
+        given(subscriptionValidationRepository.existsByCustomer(any(CustomerEntity.class))).willReturn(false);
+        given(pricingRepository.findByMemberShipEntity_Membership(any(Membership.class))).willReturn(Optional.of(pricing));
+        given(subscriptionFactory.createFromInput(any(SubscriptionFactoryDtoInput.class))).willReturn(entity);
+        given(subscriptionMutationRepository.save(any(SubscriptionEntity.class))).willReturn(savedEntity);
+        given(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class))).willReturn(response);
+
+        var result = service.create(request);
+
+        assertNotNull(result);
+        verify(customerQueryRepository).findByUserEmail(anyString());
+        verify(subscriptionValidationRepository).existsByCustomer(any(CustomerEntity.class));
+        verify(pricingRepository).findByMemberShipEntity_Membership(any(Membership.class));
+        verify(subscriptionFactory).createFromInput(any(SubscriptionFactoryDtoInput.class));
+        verify(subscriptionMutationRepository).save(any(SubscriptionEntity.class));
+        verify(subscriptionFactory).createFromEntity(any(SubscriptionEntity.class));
+        verifyNoMoreInteractions(subscriptionMutationRepository, customerQueryRepository, pricingRepository, subscriptionValidationRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw CustomerNotFoundException when customer not found")
+    void create_whenCustomerNotFound_throwsException() {
+        given(customerQueryRepository.findByUserEmail(anyString())).willReturn(Optional.empty());
+
+        assertThrows(CustomerNotFoundException.class, () -> service.create(request));
+
+        verify(customerQueryRepository).findByUserEmail(anyString());
+        verifyNoInteractions(subscriptionMutationRepository, pricingRepository, subscriptionValidationRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw AlreadyExistsException when subscription already exists")
+    void create_whenAlreadyExists_throwsException() {
+        var customer = mock(CustomerEntity.class);
+        given(customerQueryRepository.findByUserEmail(anyString())).willReturn(Optional.of(customer));
+        given(subscriptionValidationRepository.existsByCustomer(any(CustomerEntity.class))).willReturn(true);
+
+        assertThrows(AlreadyExistsException.class, () -> service.create(request));
+
+        verify(customerQueryRepository).findByUserEmail(anyString());
+        verify(subscriptionValidationRepository).existsByCustomer(any(CustomerEntity.class));
+        verifyNoInteractions(subscriptionMutationRepository, pricingRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw PricingNotFoundException when pricing not found")
+    void create_whenPricingNotFound_throwsException() {
+        var customer = mock(CustomerEntity.class);
+        given(customerQueryRepository.findByUserEmail(anyString())).willReturn(Optional.of(customer));
+        given(subscriptionValidationRepository.existsByCustomer(any(CustomerEntity.class))).willReturn(false);
+        given(pricingRepository.findByMemberShipEntity_Membership(any(Membership.class))).willReturn(Optional.empty());
+
+        assertThrows(PricingNotFoundException.class, () -> service.create(request));
+
+        verify(customerQueryRepository).findByUserEmail(anyString());
+        verify(subscriptionValidationRepository).existsByCustomer(any(CustomerEntity.class));
+        verify(pricingRepository).findByMemberShipEntity_Membership(any(Membership.class));
+        verifyNoInteractions(subscriptionMutationRepository, subscriptionFactory);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/FinalizeSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/FinalizeSubscriptionUseCaseServiceTest.java
@@ -1,0 +1,85 @@
+package com.jame.dev.gymApp.subscription.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.service.mutation.FinalizeSubscriptionUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FinalizeSubscriptionUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionQueryRepository subscriptionQueryRepository;
+
+    @Mock
+    private SubscriptionMutationRepository subscriptionMutationRepository;
+
+    @Mock
+    private SubscriptionFactory subscriptionFactory;
+
+    @InjectMocks
+    private FinalizeSubscriptionUseCaseService service;
+
+    @Captor
+    private ArgumentCaptor<SubscriptionEntity> subscriptionCaptor;
+
+    @Test
+    @DisplayName("Should finalize subscription and return SubscriptionResponse")
+    void finalize_finalizesAndReturnsResponse() {
+        var entity = new SubscriptionEntity();
+        var savedEntity = new SubscriptionEntity();
+        var response = mock(SubscriptionResponse.class);
+
+        given(subscriptionQueryRepository.findById(anyLong())).willReturn(Optional.of(entity));
+        given(subscriptionMutationRepository.save(any(SubscriptionEntity.class))).willReturn(savedEntity);
+        given(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class))).willReturn(response);
+
+        var result = service.finalize(1L);
+
+        assertNotNull(result);
+        assertTrue(entity.isFinished());
+        assertNotNull(entity.getUpdatedAt());
+
+        verify(subscriptionQueryRepository).findById(anyLong());
+        verify(subscriptionMutationRepository).save(subscriptionCaptor.capture());
+        verify(subscriptionFactory).createFromEntity(any(SubscriptionEntity.class));
+
+        var captured = subscriptionCaptor.getValue();
+        assertSame(entity, captured);
+        assertTrue(captured.isFinished());
+        assertNotNull(captured.getUpdatedAt());
+
+        verifyNoMoreInteractions(subscriptionQueryRepository, subscriptionMutationRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw SubscriptionNotFoundException when subscription not found")
+    void finalize_whenSubscriptionNotFound_throwsException() {
+        given(subscriptionQueryRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        assertThrows(SubscriptionNotFoundException.class, () -> service.finalize(1L));
+
+        verify(subscriptionQueryRepository).findById(anyLong());
+        verifyNoInteractions(subscriptionMutationRepository, subscriptionFactory);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/RenewSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/RenewSubscriptionUseCaseServiceTest.java
@@ -1,0 +1,77 @@
+package com.jame.dev.gymApp.subscription.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionUpdater;
+import com.jame.dev.gymApp.features.subscription.application.service.mutation.RenewSubscriptionUseCaseService;
+import com.jame.dev.gymApp.features.subscription.application.support.validator.SubscriptionValidator;
+import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
+import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RenewSubscriptionUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionValidator validator;
+
+    @Mock
+    private PricingRepository pricingRepository;
+
+    @Mock
+    private SubscriptionUpdater subscriptionUpdater;
+
+    @Mock
+    private SubscriptionMutationRepository subscriptionMutationRepository;
+
+    @Mock
+    private SubscriptionFactory subscriptionFactory;
+
+    @InjectMocks
+    private RenewSubscriptionUseCaseService service;
+
+    private final SubscriptionRequest input = new SubscriptionRequest("customer@mail.com", Membership.MONTHLY);
+
+    @Test
+    @DisplayName("Should renew subscription and return SubscriptionResponse")
+    void renew_renewsAndReturnsResponse() {
+        var subscription = mock(SubscriptionEntity.class);
+        var pricing = mock(PricingEntity.class);
+        var renewedEntity = mock(SubscriptionEntity.class);
+        var response = mock(SubscriptionResponse.class);
+
+        given(validator.validateOnRenew(anyLong(), any(SubscriptionRequest.class))).willReturn(subscription);
+        given(pricingRepository.findByMemberShipEntity_Membership(any(Membership.class))).willReturn(Optional.of(pricing));
+        willDoNothing().given(subscriptionUpdater).applyRenew(any(SubscriptionEntity.class), any(PricingEntity.class));
+        given(subscriptionMutationRepository.save(any(SubscriptionEntity.class))).willReturn(renewedEntity);
+        given(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class))).willReturn(response);
+
+        var result = service.renew(1L, input);
+
+        assertNotNull(result);
+        verify(validator).validateOnRenew(anyLong(), any(SubscriptionRequest.class));
+        verify(pricingRepository).findByMemberShipEntity_Membership(any(Membership.class));
+        verify(subscriptionUpdater).applyRenew(any(SubscriptionEntity.class), any(PricingEntity.class));
+        verify(subscriptionMutationRepository).save(any(SubscriptionEntity.class));
+        verify(subscriptionFactory).createFromEntity(any(SubscriptionEntity.class));
+        verifyNoMoreInteractions(validator, pricingRepository, subscriptionUpdater, subscriptionMutationRepository, subscriptionFactory);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/SoftDeleteSubscriptionByIdUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/SoftDeleteSubscriptionByIdUseCaseServiceTest.java
@@ -1,0 +1,32 @@
+package com.jame.dev.gymApp.subscription.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.application.service.mutation.SoftDeleteSubscriptionByIdUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SoftDeleteSubscriptionByIdUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionMutationRepository subscriptionMutationRepository;
+
+    @InjectMocks
+    private SoftDeleteSubscriptionByIdUseCaseService service;
+
+    @Test
+    @DisplayName("Should call repository deleteById")
+    void softDeleteById_callsRepositoryDeleteById() {
+        service.softDeleteById(1L);
+
+        verify(subscriptionMutationRepository).deleteById(anyLong());
+        verifyNoMoreInteractions(subscriptionMutationRepository);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/UpdateSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/UpdateSubscriptionUseCaseServiceTest.java
@@ -1,0 +1,106 @@
+package com.jame.dev.gymApp.subscription.usecases.mutation;
+
+import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionUpdater;
+import com.jame.dev.gymApp.features.subscription.application.service.mutation.UpdateSubscriptionUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.exception.PricingNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
+import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateSubscriptionUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionQueryRepository subscriptionQueryRepository;
+
+    @Mock
+    private PricingRepository pricingRepository;
+
+    @Mock
+    private SubscriptionUpdater subscriptionUpdater;
+
+    @Mock
+    private SubscriptionMutationRepository subscriptionMutationRepository;
+
+    @Mock
+    private SubscriptionFactory subscriptionFactory;
+
+    @InjectMocks
+    private UpdateSubscriptionUseCaseService service;
+
+    private final SubscriptionRequest request = new SubscriptionRequest("customer@mail.com", Membership.MONTHLY);
+
+    @Test
+    @DisplayName("Should update and return SubscriptionResponse when subscription exists")
+    void update_updatesAndReturnsResponse() {
+        var subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setUpdatedAt(Instant.now());
+        var pricing = new PricingEntity();
+        var modifiedEntity = new SubscriptionEntity();
+        var response = mock(SubscriptionResponse.class);
+
+        given(subscriptionQueryRepository.findById(anyLong())).willReturn(Optional.of(subscriptionEntity));
+        given(pricingRepository.findByMemberShipEntity_Membership(any(Membership.class))).willReturn(Optional.of(pricing));
+        willDoNothing().given(subscriptionUpdater).apply(any(SubscriptionEntity.class), any(PricingEntity.class));
+        given(subscriptionMutationRepository.save(any(SubscriptionEntity.class))).willReturn(modifiedEntity);
+        given(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class))).willReturn(response);
+
+        var result = service.update(1L, request);
+
+        assertNotNull(result);
+        verify(subscriptionQueryRepository).findById(anyLong());
+        verify(pricingRepository).findByMemberShipEntity_Membership(any(Membership.class));
+        verify(subscriptionUpdater).apply(any(SubscriptionEntity.class), any(PricingEntity.class));
+        verify(subscriptionMutationRepository).save(any(SubscriptionEntity.class));
+        verify(subscriptionFactory).createFromEntity(any(SubscriptionEntity.class));
+        verifyNoMoreInteractions(subscriptionQueryRepository, pricingRepository, subscriptionUpdater, subscriptionMutationRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw SubscriptionNotFoundException when subscription not found")
+    void update_whenSubscriptionNotFound_throwsException() {
+        given(subscriptionQueryRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        assertThrows(SubscriptionNotFoundException.class, () -> service.update(1L, request));
+
+        verify(subscriptionQueryRepository).findById(anyLong());
+        verifyNoInteractions(pricingRepository, subscriptionUpdater, subscriptionMutationRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw PricingNotFoundException when pricing not found")
+    void update_whenPricingNotFound_throwsException() {
+        var subscriptionEntity = new SubscriptionEntity();
+        given(subscriptionQueryRepository.findById(anyLong())).willReturn(Optional.of(subscriptionEntity));
+        given(pricingRepository.findByMemberShipEntity_Membership(any(Membership.class))).willReturn(Optional.empty());
+
+        assertThrows(PricingNotFoundException.class, () -> service.update(1L, request));
+
+        verify(subscriptionQueryRepository).findById(anyLong());
+        verify(pricingRepository).findByMemberShipEntity_Membership(any(Membership.class));
+        verifyNoInteractions(subscriptionUpdater, subscriptionMutationRepository, subscriptionFactory);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/query/GetByEmailSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/query/GetByEmailSubscriptionUseCaseServiceTest.java
@@ -1,0 +1,62 @@
+package com.jame.dev.gymApp.subscription.usecases.query;
+
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.service.query.GetByEmailSubscriptionUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetByEmailSubscriptionUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionQueryRepository subscriptionQueryRepository;
+
+    @Mock
+    private SubscriptionFactory subscriptionFactory;
+
+    @InjectMocks
+    private GetByEmailSubscriptionUseCaseService service;
+
+    @Test
+    @DisplayName("Should return SubscriptionResponse when subscription exists by email")
+    void getByEmail_whenSubscriptionExists_returnsSubscriptionResponse() {
+        var entity = new SubscriptionEntity();
+        var response = mock(SubscriptionResponse.class);
+        given(subscriptionQueryRepository.findByCustomerEmail(anyString())).willReturn(Optional.of(entity));
+        given(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class))).willReturn(response);
+
+        var result = service.getByEmail("test@mail.com");
+
+        assertNotNull(result);
+        verify(subscriptionQueryRepository).findByCustomerEmail(anyString());
+        verify(subscriptionFactory).createFromEntity(any(SubscriptionEntity.class));
+        verifyNoMoreInteractions(subscriptionQueryRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw SubscriptionNotFoundException when subscription not found by email")
+    void getByEmail_whenSubscriptionNotFound_throwsException() {
+        given(subscriptionQueryRepository.findByCustomerEmail(anyString())).willReturn(Optional.empty());
+
+        assertThrows(SubscriptionNotFoundException.class, () -> service.getByEmail("unknown@mail.com"));
+
+        verify(subscriptionQueryRepository).findByCustomerEmail(anyString());
+        verifyNoInteractions(subscriptionFactory);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/query/GetByIdSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/query/GetByIdSubscriptionUseCaseServiceTest.java
@@ -1,0 +1,62 @@
+package com.jame.dev.gymApp.subscription.usecases.query;
+
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.service.query.GetByIdSubscriptionUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetByIdSubscriptionUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionQueryRepository subscriptionQueryRepository;
+
+    @Mock
+    private SubscriptionFactory subscriptionFactory;
+
+    @InjectMocks
+    private GetByIdSubscriptionUseCaseService service;
+
+    @Test
+    @DisplayName("Should return SubscriptionResponse when subscription exists")
+    void getById_whenSubscriptionExists_returnsSubscriptionResponse() {
+        var entity = new SubscriptionEntity();
+        var response = mock(SubscriptionResponse.class);
+        given(subscriptionQueryRepository.findById(anyLong())).willReturn(Optional.of(entity));
+        given(subscriptionFactory.createFromEntity(any(SubscriptionEntity.class))).willReturn(response);
+
+        var result = service.getById(1L);
+
+        assertNotNull(result);
+        verify(subscriptionQueryRepository).findById(anyLong());
+        verify(subscriptionFactory).createFromEntity(any(SubscriptionEntity.class));
+        verifyNoMoreInteractions(subscriptionQueryRepository, subscriptionFactory);
+    }
+
+    @Test
+    @DisplayName("Should throw SubscriptionNotFoundException when subscription not found")
+    void getById_whenSubscriptionNotFound_throwsException() {
+        given(subscriptionQueryRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        assertThrows(SubscriptionNotFoundException.class, () -> service.getById(1L));
+
+        verify(subscriptionQueryRepository).findById(anyLong());
+        verifyNoInteractions(subscriptionFactory);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/query/GetPageSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/query/GetPageSubscriptionUseCaseServiceTest.java
@@ -1,0 +1,63 @@
+package com.jame.dev.gymApp.subscription.usecases.query;
+
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.service.query.GetPageSubscriptionUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetPageSubscriptionUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionQueryRepository subscriptionQueryRepository;
+
+    @Mock
+    private SubscriptionFactory subscriptionFactory;
+
+    @Mock
+    private SortPropertyResolver subSortAppResolver;
+
+    @InjectMocks
+    private GetPageSubscriptionUseCaseService service;
+
+    @Test
+    @DisplayName("Should return page of subscriptions")
+    void getPage_returnsPageDto() {
+        var pageable = PageRequest.of(0, 5);
+        var entities = List.of(new SubscriptionEntity());
+        var page = new PageImpl<>(entities);
+        var pageDto = mock(PageDto.class);
+
+        given(subSortAppResolver.resolve(any(Pageable.class))).willReturn(pageable);
+        given(subscriptionQueryRepository.findAll(any(Specification.class), any(Pageable.class))).willReturn(page);
+        given(subscriptionFactory.createPageFrom(any())).willReturn(pageDto);
+
+        var result = service.getPage(pageable, "search");
+
+        assertNotNull(result);
+        verify(subSortAppResolver).resolve(any(Pageable.class));
+        verify(subscriptionQueryRepository).findAll(any(Specification.class), any(Pageable.class));
+        verify(subscriptionFactory).createPageFrom(any());
+        verifyNoMoreInteractions(subscriptionQueryRepository, subscriptionFactory, subSortAppResolver);
+    }
+}

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/validation/ExistsByIdAndCustomerEmailUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/validation/ExistsByIdAndCustomerEmailUseCaseServiceTest.java
@@ -1,0 +1,50 @@
+package com.jame.dev.gymApp.subscription.usecases.validation;
+
+import com.jame.dev.gymApp.features.subscription.application.service.validation.ExistsByIdAndCustomerEmailUseCaseService;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionValidationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExistsByIdAndCustomerEmailUseCaseServiceTest {
+
+    @Mock
+    private SubscriptionValidationRepository subscriptionValidationRepository;
+
+    @InjectMocks
+    private ExistsByIdAndCustomerEmailUseCaseService service;
+
+    @Test
+    @DisplayName("Should return true when subscription exists for the given id and email")
+    void existsByIdAndCustomerEmail_returnsTrue() {
+        given(subscriptionValidationRepository.existsByIdAndCustomerEmail(anyLong(), anyString())).willReturn(true);
+
+        var result = service.existsByIdAndCustomerEmail(1L, "test@mail.com");
+
+        assertTrue(result);
+        verify(subscriptionValidationRepository).existsByIdAndCustomerEmail(anyLong(), anyString());
+        verifyNoMoreInteractions(subscriptionValidationRepository);
+    }
+
+    @Test
+    @DisplayName("Should return false when subscription does not exist for the given id and email")
+    void existsByIdAndCustomerEmail_returnsFalse() {
+        given(subscriptionValidationRepository.existsByIdAndCustomerEmail(anyLong(), anyString())).willReturn(false);
+
+        var result = service.existsByIdAndCustomerEmail(1L, "unknown@mail.com");
+
+        assertFalse(result);
+        verify(subscriptionValidationRepository).existsByIdAndCustomerEmail(anyLong(), anyString());
+        verifyNoMoreInteractions(subscriptionValidationRepository);
+    }
+}


### PR DESCRIPTION
# Description

This PR refactors the Subscription feature by replacing controller inheritance with a composition-based architecture centered around dedicated use cases. The change improves separation of concerns, reduces coupling between layers, and establishes clearer boundaries between querying, mutations, validation, and persistence responsibilities.

# Main Changes

* Removed inheritance-based controller implementations and migrated controllers to explicit composition using dedicated use cases.
* Refactored `SubscriptionUserController` to inject and orchestrate individual use cases instead of relying on generic controller abstractions.
* Introduced dedicated use case contracts and implementations for subscription operations, including:

  * CreateSubscriptionUseCase
  * UpdateSubscriptionUseCase
  * RenewSubscriptionUseCase
  * FinalizeSubscriptionUseCase
  * GetByIdSubscriptionUseCase
  * GetByEmailSubscriptionUseCase
  * GetPageSubscriptionUseCase
  * ExistsByIdAndCustomerEmailUseCase
  * SoftDeleteSubscriptionByIdUseCase
* Split repository responsibilities into dedicated domain contracts:

  * SubscriptionQueryRepository
  * SubscriptionMutationRepository
  * SubscriptionValidationRepository
* Added JPA adapter implementations to bridge domain repositories and persistence infrastructure.
* Moved persistence repositories (`SubscriptionRepository`, `PricingRepository`, `MembershipRepository`, `PeriodRepository`) into the infrastructure persistence layer.
* Refactored subscription retrieval logic to use query repositories and dedicated query use cases.
* Introduced dedicated mutation services for update, renewal, finalization, and deletion workflows.
* Added validation-specific use cases and repositories for ownership and existence checks.
* Integrated cache management and audit logging into subscription mutation use cases.
* Updated subscription lookup behavior to use customer email-based queries through dedicated query repositories.
* Improved paginated subscription retrieval using use case-driven query services and specifications.

# Minimal Changes

* Updated package structures and imports after moving persistence repositories to the infrastructure layer.
* Renamed repository methods to better reflect their responsibilities and usage patterns.
* Simplified controller construction through constructor injection and composition.
* Removed dependencies on generic controller abstractions and service inheritance hierarchies.
* Updated notification and pricing services to use the new persistence package structure.
* Adjusted validation methods to remove active-state restrictions from ownership verification checks.
* Reorganized application services to align with the new architectural boundaries.
* Added comprehensive unit tests for query, mutation, and validation use cases.

# Notes

* The Subscription feature now follows a CQRS-inspired approach by separating query, mutation, and validation responsibilities into dedicated use cases.
* Composition-based controllers provide better maintainability and make dependencies explicit, reducing architectural complexity.
* The newly introduced repository adapters create a cleaner separation between domain contracts and infrastructure implementations.
* Audit logging and cache eviction are now consistently applied at the use case level, improving cross-cutting concern management.
* Similar refactoring patterns can be applied to other modules to achieve greater architectural consistency throughout the application.
* Legacy application services remain available in some areas and may be candidates for future simplification or migration to the use case model.
