### PR TITLE
Customer Response

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/audit/application/support/helper/ChangeModelResolverHelper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/application/support/helper/ChangeModelResolverHelper.java
@@ -29,7 +29,7 @@ public class ChangeModelResolverHelper {
    }
 
     static Map<String, ChangesModelCustomer> buildChangesModelCustomer(long entityId, @Nullable CustomerRequest input, CustomerResponse response) {
-      final var changesAfter = new ChangesModelCustomer(response.id(), response.user().email(), response.contact());
+      final var changesAfter = new ChangesModelCustomer(response.id(), response.customerEmail(), response.contact());
       if (input == null) return Map.of(
          "after", changesAfter
       );

--- a/src/main/java/com/jame/dev/gymApp/features/customer/api/response/CustomerResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/customer/api/response/CustomerResponse.java
@@ -1,13 +1,16 @@
 package com.jame.dev.gymApp.features.customer.api.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 import lombok.Builder;
+import org.jspecify.annotations.Nullable;
 
 @Builder
 public record CustomerResponse(
-        @JsonProperty("id") Long id,
-        @JsonProperty("user") UserResponse user,
-        @JsonProperty("contact") String contact
+        @JsonProperty("id") long id,
+        @JsonProperty("customerName") String customerName,
+        @JsonProperty("customerEmail") String customerEmail,
+        @JsonProperty("contact") String contact,
+        @JsonProperty("isSubscriber") boolean isSubscriber,
+        @JsonProperty("subscriptionId") @Nullable Long subscriptionId
 ) {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/customer/application/support/mapper/CustomerMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/customer/application/support/mapper/CustomerMapper.java
@@ -1,21 +1,41 @@
 package com.jame.dev.gymApp.features.customer.application.support.mapper;
 
-import com.jame.dev.gymApp.features.user.application.support.mapper.UserMapper;
-import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
-import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
+import com.jame.dev.gymApp.application.support.mapper.BaseMapper;
 import com.jame.dev.gymApp.features.customer.api.request.CustomerRequest;
 import com.jame.dev.gymApp.features.customer.api.response.CustomerResponse;
-import com.jame.dev.gymApp.application.support.mapper.BaseMapper;
+import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.user.application.support.mapper.UserMapper;
+import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
+import org.jspecify.annotations.Nullable;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.List;
+import java.util.Optional;
 
 @Mapper(componentModel = "spring", uses = UserMapper.class, injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 public interface CustomerMapper extends BaseMapper<CustomerEntity, CustomerResponse> {
 
    @Override
+   @Mapping(target = "customerName", source = "entity.user.name")
+   @Mapping(target = "customerEmail", source = "entity.user.email")
    @Mapping(target = "contact", source = "phoneContact")
+   @Mapping(
+      target = "isSubscriber",
+      expression = "java(!entity.getSubscriptions().isEmpty())")
+   @Mapping(target = "subscriptionId", expression = "java(mapSubscriptionId(entity))")
    CustomerResponse toDto(CustomerEntity entity);
+
+   default @Nullable Long mapSubscriptionId(CustomerEntity entity) {
+      return Optional.ofNullable(entity)
+         .map(CustomerEntity::getSubscriptions)
+         .filter(subs -> !subs.isEmpty())
+         .map(List::getLast)
+         .map(SubscriptionEntity::getId)
+         .orElse(null);
+   }
 
    default CustomerEntity toEntity(CustomerRequest dto, UserEntity user) {
       return CustomerEntity.builder()

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/CustomerAdministrationControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/CustomerAdministrationControllerTest.java
@@ -10,11 +10,8 @@ import com.jame.dev.gymApp.domain.exception.NoActiveException;
 import com.jame.dev.gymApp.features.customer.api.request.CustomerRequest;
 import com.jame.dev.gymApp.features.customer.api.response.CustomerResponse;
 import com.jame.dev.gymApp.application.dto.PageDto;
-import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 import com.jame.dev.gymApp.features.customer.application.contract.CustomerRecoverService;
 import com.jame.dev.gymApp.features.customer.application.contract.CustomerService;
-import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
-import com.jame.dev.gymApp.features.user.domain.model.Role;
 import config.TestConfig;
 import config.TestDataSource;
 import config.TestValidationConfig;
@@ -35,8 +32,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -80,9 +75,13 @@ class CustomerAdministrationControllerTest {
    private CustomerRecoverService recoverService;
 
    private final String URI_TEMPLATE = "/app/v1/administration/customers";
-   private final CustomerResponse customerResponse = new CustomerResponse(
-      1L, new UserResponse(1L, "dto", "dto@mail", AuthProvider.LOCAL, Set.of(Role.USER)), "25082525"
-   );
+   private final CustomerResponse customerResponse = CustomerResponse.builder()
+       .id(1L)
+       .customerName("dto")
+       .customerEmail("dto@mail")
+       .contact("25082525")
+       .isSubscriber(false)
+       .build();
 
    @Nested
    @DisplayName("GET Customer Resources.")

--- a/src/test/java/com/jame/dev/gymApp/customer/controller/CustomerAdministrationControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/customer/controller/CustomerAdministrationControllerTest.java
@@ -3,7 +3,6 @@ package com.jame.dev.gymApp.customer.controller;
 import com.jame.dev.gymApp.application.dto.PageDto;
 import com.jame.dev.gymApp.domain.exception.NoActiveException;
 import com.jame.dev.gymApp.features.auth.api.request.RecoveryRequest;
-import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
 import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException;
 import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthorizationFilter;
 import com.jame.dev.gymApp.features.customer.api.CustomerAdministrationController;
@@ -16,8 +15,6 @@ import com.jame.dev.gymApp.features.customer.application.usecases.mutation.Updat
 import com.jame.dev.gymApp.features.customer.application.usecases.query.GetByIdCustomerUseCase;
 import com.jame.dev.gymApp.features.customer.application.usecases.query.GetPageCustomerUseCase;
 import com.jame.dev.gymApp.features.customer.domain.exception.CustomerNotFoundException;
-import com.jame.dev.gymApp.features.user.api.response.UserResponse;
-import com.jame.dev.gymApp.features.user.domain.model.Role;
 import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
 import config.TestConfig;
@@ -42,7 +39,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.List;
-import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -103,9 +99,13 @@ class CustomerAdministrationControllerTest {
    private SoftDeleteCustomerByIdUseCase softDelete;
 
    private final String URI_TEMPLATE = "/app/v1/administration/customers";
-   private final CustomerResponse customerResponse = new CustomerResponse(
-      1L, new UserResponse(1L, "dto", "dto@mail", AuthProvider.LOCAL, Set.of(Role.USER)), "25082525"
-   );
+   private final CustomerResponse customerResponse = CustomerResponse.builder()
+       .id(1L)
+       .customerName("dto")
+       .customerEmail("dto@mail")
+       .contact("25082525")
+       .isSubscriber(false)
+       .build();
 
    @Nested
    @DisplayName("GET Customer Resources.")

--- a/src/test/java/com/jame/dev/gymApp/customer/controller/CustomerUserControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/customer/controller/CustomerUserControllerTest.java
@@ -1,7 +1,6 @@
 package com.jame.dev.gymApp.customer.controller;
 
 import com.jame.dev.gymApp.domain.exception.NoActiveException;
-import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
 import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException;
 import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthorizationFilter;
 import com.jame.dev.gymApp.features.customer.api.CustomerUserController;
@@ -13,8 +12,6 @@ import com.jame.dev.gymApp.features.customer.application.usecases.mutation.Updat
 import com.jame.dev.gymApp.features.customer.application.usecases.query.GetByEmailCustomerUseCase;
 import com.jame.dev.gymApp.features.customer.application.usecases.query.GetByIdCustomerUseCase;
 import com.jame.dev.gymApp.features.customer.domain.exception.CustomerNotFoundException;
-import com.jame.dev.gymApp.features.user.api.response.UserResponse;
-import com.jame.dev.gymApp.features.user.domain.model.Role;
 import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
 import config.TestConfig;
@@ -37,8 +34,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -95,9 +90,13 @@ class CustomerUserControllerTest {
    private SoftDeleteCustomerByIdUseCase softDelete;
 
    private final String URI_TEMPLATE = "/app/v1/customers";
-   private final CustomerResponse customerResponse = new CustomerResponse(
-      1L, new UserResponse(1L, "dto", "dto@mail", AuthProvider.LOCAL, Set.of(Role.USER)), "25082525"
-   );
+   private final CustomerResponse customerResponse = CustomerResponse.builder()
+       .id(1L)
+       .customerName("dto")
+       .customerEmail("dto@mail")
+       .contact("25082525")
+       .isSubscriber(false)
+       .build();
 
    @Nested
    @DisplayName("GET Customer Resources.")

--- a/src/test/java/com/jame/dev/gymApp/customer/usecases/mutation/RecoverCustomerUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/customer/usecases/mutation/RecoverCustomerUseCaseServiceTest.java
@@ -1,6 +1,7 @@
 package com.jame.dev.gymApp.customer.usecases.mutation;
 
 import com.jame.dev.gymApp.features.auth.api.request.RecoveryRequest;
+import com.jame.dev.gymApp.features.customer.application.contract.CustomerFactory;
 import com.jame.dev.gymApp.features.customer.application.service.mutation.RecoverCustomerUseCaseService;
 import com.jame.dev.gymApp.features.customer.domain.repository.CustomerMutationRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -18,6 +20,9 @@ class RecoverCustomerUseCaseServiceTest {
 
     @Mock
     private CustomerMutationRepository customerMutationRepository;
+
+    @Mock
+   private CustomerFactory customerFactory;
 
     @InjectMocks
     private RecoverCustomerUseCaseService service;
@@ -30,6 +35,7 @@ class RecoverCustomerUseCaseServiceTest {
         service.recover(request);
 
         verify(customerMutationRepository).recoverByUserEmail(request.email());
-        verifyNoMoreInteractions(customerMutationRepository);
+        verify(customerFactory).createFromEntity(any());
+        verifyNoMoreInteractions(customerMutationRepository, customerFactory);
     }
 }

--- a/src/test/java/com/jame/dev/gymApp/mapper/CustomerMapperTest.java
+++ b/src/test/java/com/jame/dev/gymApp/mapper/CustomerMapperTest.java
@@ -5,44 +5,24 @@ import com.jame.dev.gymApp.features.customer.api.response.CustomerResponse;
 import com.jame.dev.gymApp.features.customer.application.support.mapper.CustomerMapper;
 import com.jame.dev.gymApp.features.customer.application.support.mapper.CustomerMapperImpl;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
-import com.jame.dev.gymApp.features.user.application.support.mapper.RoleMapper;
-import com.jame.dev.gymApp.features.user.application.support.mapper.RoleMapperImpl;
-import com.jame.dev.gymApp.features.user.application.support.mapper.UserMapper;
-import com.jame.dev.gymApp.features.user.application.support.mapper.UserMapperImpl;
-import com.jame.dev.gymApp.features.user.domain.model.Role;
-import com.jame.dev.gymApp.features.user.domain.model.RoleEntity;
-import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
 class CustomerMapperTest {
-   private final RoleMapper roleMapper = new RoleMapperImpl();
-   private final UserMapper userMapper = new UserMapperImpl(roleMapper);
-   private final CustomerMapper customerMapper = new CustomerMapperImpl(userMapper);
-
-   private final UserEntity testUser = UserEntity.builder()
-           .name("user")
-           .email("user@maul.com")
-           .password("12bf4")
-           .roles(Set.of(new RoleEntity(null, Role.USER)))
-           .build();
+   private final CustomerMapper customerMapper = new CustomerMapperImpl();
 
    @Test
    void toDto() {
-      CustomerResponse dto = customerMapper.toDto(
-              CustomerEntity.builder()
-                      .user(testUser)
-                      .phoneContact("128133")
-                      .build());
+      CustomerResponse dto = customerMapper.toDto(new CustomerEntity());
       Assertions.assertNotNull(dto, "Should not be null.");
    }
 
    @Test
    void toEntity() {
       CustomerRequest dto = new CustomerRequest("any@mail.com", "347293");
-      CustomerEntity entity = customerMapper.toEntity(dto, testUser);
+      CustomerEntity entity = customerMapper.toEntity(dto, new com.jame.dev.gymApp.features.user.domain.model.UserEntity());
       Assertions.assertNotNull(entity, "Should not be null.");
    }
 }


### PR DESCRIPTION
# Description

This PR refactors the `CustomerResponse` record to provide a more customer-oriented response model, exposing relevant customer information directly instead of relying on nested user structures. The changes improve API clarity, reduce coupling with user-related DTOs, and enrich the customer response with subscription-related data.

# Main Changes

* Refactored `CustomerResponse` to expose customer-specific fields directly:

  * Added `customerName`.
  * Added `customerEmail`.
  * Added `isSubscriber`.
  * Added `subscriptionId`.
* Removed the dependency on the nested `UserResponse` object from `CustomerResponse`.
* Updated `CustomerMapper` mappings to populate the new response structure from the associated user entity.
* Added subscription-related mapping logic:

  * Determines whether a customer is currently subscribed.
  * Resolves the latest subscription identifier when available.
* Updated audit change tracking logic to use the new `customerEmail` property instead of accessing email through a nested user object.
* Adjusted controller and mapper tests to reflect the new response contract and builder-based construction.

# Minimal Changes

* Replaced wrapper type `Long` with primitive `long` for the customer identifier in `CustomerResponse`.
* Added nullable support for `subscriptionId`.
* Removed unused imports related to:

  * `UserResponse`
  * `AuthProvider`
  * `Role`
  * `Set`
  * Mapper dependencies no longer required after the refactor.
* Simplified `CustomerMapperTest` setup by removing unnecessary mapper and entity initialization.
* Updated mock verifications in `RecoverCustomerUseCaseServiceTest` to include interactions with `CustomerFactory`.

# Notes

* This refactor makes the customer API contract more focused on customer-related information and less dependent on user implementation details.
* Consumers of the API must be updated to use the new response fields (`customerName`, `customerEmail`, `isSubscriber`, `subscriptionId`) instead of the previous nested `user` object.
* Future improvements could include exposing richer subscription metadata (status, expiration date, plan information) directly within the customer response when required by the frontend.
