### PR TITLE
Subscription payment renewal.

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionUserController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionUserController.java
@@ -65,7 +65,7 @@ public class SubscriptionUserController {
       final SubscriptionCheckoutResponse checkoutResponse = stripeCheckoutService.createCheckoutSession(
          new CheckoutRequest(input.membership(), input.customerEmail())
       );
-
+      
       final SubscriptionResponse subscription = subscriptionCreate.create(input);
 
       final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -80,14 +80,22 @@ public class SubscriptionUserController {
 
    @PreAuthorize("@subscriptionSecurity.isOwner(#id, authentication)")
    @PutMapping("/{id}")
-   public ResponseEntity<SubscriptionResponse> renew(
+   public ResponseEntity<SubscriptionSessionResponse> renew(
       @PathVariable("id")
       @Minimum final long id,
       @Valid
       @RequestBody
       @NotNullObject final SubscriptionRequest input) {
-      final SubscriptionResponse response = subscriptionRenew.renew(id, input);
-      return ResponseEntity.ok(response);
+
+      final SubscriptionCheckoutResponse checkoutResponse = stripeCheckoutService.createCheckoutSession(
+         new CheckoutRequest(input.membership(), input.customerEmail())
+      );
+
+      final SubscriptionResponse subscription = subscriptionRenew.renew(id, input);
+
+      final SubscriptionSessionResponse body = new SubscriptionSessionResponse(checkoutResponse, subscription);
+
+      return ResponseEntity.ok(body);
    }
 
    @PreAuthorize("@subscriptionSecurity.isOwner(#id, authentication)")

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
@@ -17,40 +17,49 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
 import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTIONS;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CompletedCheckoutUseCaseService implements CompletedCheckoutUseCase {
-    private final SubscriptionQueryRepository subscriptionQueryRepository;
-    private final PaymentMutationRepository paymentMutationRepository;
-    private final PaymentFactory paymentFactory;
-    private final ApplicationEventPublisher eventPublisher;
+   private final SubscriptionQueryRepository subscriptionQueryRepository;
+   private final PaymentMutationRepository paymentMutationRepository;
+   private final PaymentFactory paymentFactory;
+   private final ApplicationEventPublisher eventPublisher;
 
-    @Override
-    @Transactional
-    @CacheEvict(value = SUBSCRIPTIONS, allEntries = true)
-    public void execute(CompletedCheckoutEvent event) {
-        final SubscriptionEntity subscription = subscriptionQueryRepository.findByCustomerEmail(event.customerEmail())
-           .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not found for: " + event.customerEmail()));
+   @Override
+   @Transactional
+   @CacheEvict(value = SUBSCRIPTIONS, allEntries = true)
+   public void execute(CompletedCheckoutEvent event) {
+      final SubscriptionEntity subscription = subscriptionQueryRepository.findByCustomerEmail(event.customerEmail())
+         .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not found for: " + event.customerEmail()));
 
-        final StripeSessionPaymentEvent paymentEvent = StripeSessionPaymentEvent.builder()
-           .sessionId(event.stripeSessionId())
-           .intentId(event.stripePaymentIntentId())
-           .subscriptionId(event.stripeSubscriptionId())
-           .subscriptionEntity(subscription)
-           .isPhysicSession(false)
-           .build();
+      Optional.ofNullable(subscription.getPayments())
+         .filter(Predicate.not(List::isEmpty))
+         .map(List::getLast)
+         .ifPresent(payment -> payment.setStatus(PaymentStatus.FINALIZED));
 
-        final PaymentEntity payment = paymentFactory.from(paymentEvent);
+      final StripeSessionPaymentEvent paymentEvent = StripeSessionPaymentEvent.builder()
+         .sessionId(event.stripeSessionId())
+         .intentId(event.stripePaymentIntentId())
+         .subscriptionId(event.stripeSubscriptionId())
+         .subscriptionEntity(subscription)
+         .isPhysicSession(false)
+         .build();
 
-        final PaymentEntity paymentEntity = paymentMutationRepository.save(payment);
+      final PaymentEntity payment = paymentFactory.from(paymentEvent);
 
-        subscription.setPaid(paymentEntity.getStatus() == PaymentStatus.COMPLETED);
-        //eventPublisher.publishEvent(event);
+      final PaymentEntity paymentEntity = paymentMutationRepository.save(payment);
 
-        log.info("Checkout completed: session={}, subscription={}, customer={}",
-            event.stripeSessionId(), subscription.getId(), event.customerEmail());
-    }
+      subscription.setPaid(paymentEntity.getStatus() == PaymentStatus.COMPLETED);
+      //eventPublisher.publishEvent(event);
+
+      log.info("Checkout completed: session={}, subscription={}, customer={}",
+         event.stripeSessionId(), subscription.getId(), event.customerEmail());
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/PaymentStatus.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/PaymentStatus.java
@@ -1,5 +1,5 @@
 package com.jame.dev.gymApp.features.subscription.domain.model;
 
 public enum PaymentStatus {
-    PENDING, COMPLETED, FAILED, REFUNDED
+    PENDING, COMPLETED, FAILED, REFUNDED, FINALIZED
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/SubscriptionEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/SubscriptionEntity.java
@@ -2,6 +2,7 @@ package com.jame.dev.gymApp.features.subscription.domain.model;
 
 import com.jame.dev.gymApp.domain.model.BaseEntity;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
@@ -50,14 +51,20 @@ public class SubscriptionEntity extends BaseEntity {
          name = "fk_subscription_period_id",
          foreignKeyDefinition = "FOREIGN KEY (subscription_id) REFERENCES subscriptions(id) ON DELETE CASCADE"
       )
-   )
-   private List<PeriodEntity> subscriptionPeriods = new LinkedList<>();
+    )
+    private List<PeriodEntity> subscriptionPeriods = new LinkedList<>();
 
-   @Column(name = "finished", nullable = false)
-   private boolean finished;
+    @OneToMany(mappedBy = "subscription", fetch = FetchType.LAZY,
+               cascade = {CascadeType.MERGE, CascadeType.REFRESH})
+    @JsonIgnore
+    @Builder.Default
+    private List<PaymentEntity> payments = new LinkedList<>();
 
-   @Column(name = "paid", nullable = false)
-   private boolean paid = false;
+    @Column(name = "finished", nullable = false)
+    private boolean finished;
+
+    @Column(name = "paid", nullable = false)
+    private boolean paid = false;
 
    @PostPersist
    private void setStatus() {


### PR DESCRIPTION
# Description

This PR introduces the subscription renewal flow integrated with the payment lifecycle, ensuring that subscription and payment records remain synchronized during renewal operations. It also establishes a mechanism to transition previous payments when a new renewal checkout is completed, allowing the subscription state to accurately reflect the latest payment status.

# Main Changes

* Added subscription renewal checkout flow, returning both the Stripe checkout session information and the renewed subscription data in a single response.
* Updated the subscription renewal endpoint to create a new checkout session before processing the renewal.
* Implemented synchronization between subscription renewals and payment records.
* Added support for the new `FINALIZED` payment status.
* Updated checkout completion logic to automatically mark the latest existing payment as `FINALIZED` before creating and storing a new payment record.
* Added a bidirectional relationship between `SubscriptionEntity` and `PaymentEntity`, enabling direct access to subscription payments.
* Updated subscription payment state handling to ensure the `paid` flag reflects the status of the latest payment transaction.

# Minimal Changes

* Added required imports for `Optional`, `List`, and `Predicate`.
* Added `@JsonIgnore` to prevent payment collections from being serialized.
* Adjusted formatting and indentation in affected classes.
* Updated controller response type for renewal operations.
* Removed minor unused spacing inconsistencies.

# Notes

* The current implementation assumes that only the latest payment associated with a subscription should remain active, while previous payments are transitioned to `FINALIZED`.
* Additional validation could be introduced to prevent concurrent renewal requests from creating overlapping payment records.
* Future improvements may include a more explicit payment history strategy, exposing finalized payments through dedicated endpoints or reporting features.
* Consider publishing domain events after checkout completion once the event-driven workflow is fully implemented and validated.
