### PR TITLE
Customer Payments

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/application/model/CacheValues.java
+++ b/src/main/java/com/jame/dev/gymApp/application/model/CacheValues.java
@@ -5,6 +5,7 @@ public class CacheValues {
    public static final String CUSTOMERS = "customers";
    public static final String SUBSCRIPTIONS = "subscriptions";
    public static final String USERS_INACTIVE = "users:inactive";
+   public static final String PAYMENTS = "payments";
 
    public static final String USER = "user";
    public static final String CUSTOMER = "customer";

--- a/src/main/java/com/jame/dev/gymApp/domain/model/BaseEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/domain/model/BaseEntity.java
@@ -50,4 +50,8 @@ public abstract class BaseEntity {
       return getClass().hashCode();
    }
 
+   @PrePersist
+   public void setCreatedAt() {
+      this.createdAt = Instant.now();
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/PaymentUserController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/PaymentUserController.java
@@ -1,0 +1,41 @@
+package com.jame.dev.gymApp.features.subscription.api;
+
+
+import com.jame.dev.gymApp.features.subscription.api.response.PaymentResponse;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetPaymentPageByCustomerId;
+import com.jame.dev.gymApp.infrastructure.annotation.Minimum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/app/v1/subscribers/payments")
+@PreAuthorize("hasRole('USER')")
+@RequiredArgsConstructor
+public class PaymentUserController {
+
+   private final GetPaymentPageByCustomerId getPaymentPageByCustomerId;
+
+   @PreAuthorize("@customerSecurity.isOwner(#customerId, authentication)")
+   @GetMapping("/{customerId}/customers")
+   public ResponseEntity<Page<PaymentResponse>> getPaymentPageByCustomerId(
+      @Minimum
+      @PathVariable("customerId") final long customerId,
+      @PageableDefault(
+         sort = "id",
+         direction = Sort.Direction.DESC
+      ) final Pageable pageable) {
+      final var pageDto = getPaymentPageByCustomerId.getPageByCustomerId(customerId, pageable);
+      final Page<PaymentResponse> page = new PageImpl<>(pageDto.content(), pageable, pageDto.totalElements());
+      return ResponseEntity.ok(page);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionUserController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/SubscriptionUserController.java
@@ -76,13 +76,13 @@ public class SubscriptionUserController {
       return ResponseEntity.ok(response);
    }
 
-   @PreAuthorize("@subscriptionSecurity.isOwner(#customerEmail, authentication)")
-   @GetMapping(params = "customerEmail")
+   @GetMapping("/current")
    public ResponseEntity<Page<SubscriptionResponse>> getAllByCustomerEmail(
-      @RequestParam(value = "customerEmail")
-      @EmailValid final String customerEmail,
-      @PageableDefault(sort = "id", direction = Sort.Direction.DESC) final Pageable pageable) {
-      final PageDto<SubscriptionResponse> page = subscriptionGetAllByCustomerEmail.getAllByCustomerEmail(customerEmail, pageable);
+      @PageableDefault(sort = "id", direction = Sort.Direction.DESC)
+      final Pageable pageable,
+      final Authentication authentication) {
+      final String principal = extractorService.extract(authentication);
+      final PageDto<SubscriptionResponse> page = subscriptionGetAllByCustomerEmail.getAllByCustomerEmail(principal, pageable);
       final Page<SubscriptionResponse> responsePage = new PageImpl<>(page.content(), pageable, page.totalElements());
       return ResponseEntity.ok(responsePage);
    }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/response/PaymentResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/response/PaymentResponse.java
@@ -1,0 +1,17 @@
+package com.jame.dev.gymApp.features.subscription.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.subscription.domain.model.PaymentMethod;
+import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record PaymentResponse(
+   @JsonProperty("id") Long id,
+   @JsonProperty("amount") BigDecimal amount,
+   @JsonProperty("status") PaymentStatus status,
+   @JsonProperty("paymentMethod") PaymentMethod paymentMethod,
+   @JsonProperty("createdAt") Instant createdAt
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
@@ -32,7 +32,8 @@ public class CompletedCheckoutUseCaseService implements CompletedCheckoutUseCase
    @Caching(
       evict = {
          @CacheEvict(value = CacheValues.SUBSCRIPTIONS, allEntries = true),
-         @CacheEvict(value = CacheValues.SUBSCRIPTION, allEntries = true)
+         @CacheEvict(value = CacheValues.SUBSCRIPTION, allEntries = true),
+         @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true)
       }
    )
    public void execute(CompletedCheckoutEvent event) {

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreatePaymentUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreatePaymentUseCaseService.java
@@ -1,5 +1,6 @@
 package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 
+import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.features.subscription.api.request.PaymentRequest;
 import com.jame.dev.gymApp.features.subscription.application.support.factory.PaymentFactory;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreatePaymentUseCase;
@@ -10,6 +11,7 @@ import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity
 import com.jame.dev.gymApp.features.subscription.domain.repository.PaymentMutationRepository;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ public class CreatePaymentUseCaseService implements CreatePaymentUseCase {
 
    @Override
    @Transactional
+   @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true)
    public void create(PaymentRequest paymentRequest) {
       final SubscriptionEntity subscriptionEntity = subscriptionQueryRepository.findById(paymentRequest.subscriptionId())
          .orElseThrow(() -> new SubscriptionNotFoundException("Subscription not found for id: " + paymentRequest.subscriptionId()));

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
@@ -1,5 +1,6 @@
 package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 
+import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
@@ -11,9 +12,10 @@ import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
-import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTION;
+import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTIONS;
 
 @Slf4j
 @Service
@@ -32,7 +37,22 @@ public class FinalizeSubscriptionUseCaseService implements FinalizeSubscriptionU
 
    @Override
    @Transactional
-   @CacheEvictSubscriptions
+   @Caching(evict = {
+      @CacheEvict(
+         value = SUBSCRIPTIONS,
+         allEntries = true,
+         beforeInvocation = true,
+         cacheManager = "redisCacheManager"),
+      @CacheEvict(
+         value = SUBSCRIPTION,
+         key = "#id",
+         cacheManager = "redisCacheManager"
+      ),
+      @CacheEvict(
+         value = CacheValues.PAYMENTS, allEntries = true,
+         cacheManager = "redisCacheManager"
+      )
+   })
    @AuditLog(
       action = AuditLogAction.UPDATE,
       entityType = AuditLogEntityType.SUBSCRIPTION,
@@ -51,7 +71,7 @@ public class FinalizeSubscriptionUseCaseService implements FinalizeSubscriptionU
          .ifPresent(p -> {
             p.setStatus(PaymentStatus.FINALIZED);
             p.setUpdatedAt(updatedAt);
-            p.setActive(false);
+            //p.setActive(false);
             log.info("check payment.");
          });
 

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
@@ -1,29 +1,51 @@
 package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 
+import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.SoftDeleteSubscriptionByIdUseCase;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
-import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTION;
+import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTIONS;
 
 @Service
 @RequiredArgsConstructor
 public class SoftDeleteSubscriptionByIdUseCaseService implements SoftDeleteSubscriptionByIdUseCase {
-    private final SubscriptionMutationRepository subscriptionMutationRepository;
+   private final SubscriptionMutationRepository subscriptionMutationRepository;
 
-    @Override
-    @Transactional
-    @CacheEvictSubscriptions
-    @AuditLog(
-        action = AuditLogAction.DELETE,
-        entityType = AuditLogEntityType.SUBSCRIPTION,
-        entityId = "#id"
-    )
-    public void softDeleteById(long id) {
-        subscriptionMutationRepository.deleteById(id);
-    }
+   @Override
+   @Transactional
+   @Caching(evict = {
+      @CacheEvict(
+         value = SUBSCRIPTIONS,
+         allEntries = true,
+         beforeInvocation = true,
+         cacheManager = "redisCacheManager"),
+      @CacheEvict(
+         value = SUBSCRIPTION,
+         key = "#id",
+         cacheManager = "redisCacheManager"
+      ),
+      @CacheEvict(
+         value = CacheValues.PAYMENTS,
+         allEntries = true,
+         cacheManager = "redisCacheManager",
+         beforeInvocation = true
+      )
+   })
+   @AuditLog(
+      action = AuditLogAction.DELETE,
+      entityType = AuditLogEntityType.SUBSCRIPTION,
+      entityId = "#id"
+   )
+   public void softDeleteById(long id) {
+      subscriptionMutationRepository.deleteById(id);
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetPaymentPageByCustomerIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetPaymentPageByCustomerIdUseCaseService.java
@@ -1,0 +1,43 @@
+package com.jame.dev.gymApp.features.subscription.application.service.query;
+
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.application.model.CacheValues;
+import com.jame.dev.gymApp.features.subscription.api.response.PaymentResponse;
+import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetPaymentPageByCustomerId;
+import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.PaymentQueryRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.payment.mapper.PaymentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetPaymentPageByCustomerIdUseCaseService implements GetPaymentPageByCustomerId {
+   private final PaymentQueryRepository paymentQueryRepository;
+   private final PaymentMapper paymentMapper;
+
+   @Override
+   @Cacheable(
+      value = CacheValues.PAYMENTS,
+      keyGenerator = "pageKeyGenerator",
+      unless = "#result == null || #result.content.isEmpty()"
+   )
+   public PageDto<PaymentResponse> getPageByCustomerId(Long customerId, Pageable pageable) {
+      final Page<PaymentEntity> entityPage = paymentQueryRepository.findPaymentPage(customerId, pageable);
+      final var content = entityPage.getContent().stream()
+         .map(paymentMapper::toResponse)
+         .toList();
+      return new PageDto<>(
+         content,
+         entityPage.getNumber(),
+         entityPage.getSize(),
+         entityPage.getTotalElements(),
+         entityPage.getSort().toString(),
+         entityPage.getSort().isSorted() ? "ASC" : "DESC");
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetPaymentPageByCustomerId.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetPaymentPageByCustomerId.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.features.subscription.application.usecases.query;
+
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.features.subscription.api.response.PaymentResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface GetPaymentPageByCustomerId {
+   PageDto<PaymentResponse> getPageByCustomerId(final Long customerId, final Pageable pageable);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/PaymentQueryRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/PaymentQueryRepository.java
@@ -2,12 +2,16 @@ package com.jame.dev.gymApp.features.subscription.domain.repository;
 
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 public interface PaymentQueryRepository {
+
+   Page<PaymentEntity> findPaymentPage(final Long customerId, final Pageable pageable);
 
     Optional<PaymentEntity> findById(final long id);
 

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/PaymentQueryJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/PaymentQueryJpaRepositoryAdapter.java
@@ -5,6 +5,8 @@ import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
 import com.jame.dev.gymApp.features.subscription.domain.repository.PaymentQueryRepository;
 import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PaymentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
@@ -16,7 +18,12 @@ import java.util.Optional;
 public class PaymentQueryJpaRepositoryAdapter implements PaymentQueryRepository {
     private final PaymentRepository paymentRepository;
 
-    @Override
+   @Override
+   public Page<PaymentEntity> findPaymentPage(Long customerId, Pageable pageable) {
+      return paymentRepository.findAll(customerId, pageable);
+   }
+
+   @Override
     public Optional<PaymentEntity> findById(long id) {
         return paymentRepository.findById(id);
     }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/payment/mapper/PaymentMapper.java
@@ -1,0 +1,13 @@
+package com.jame.dev.gymApp.features.subscription.infrastructure.payment.mapper;
+
+import com.jame.dev.gymApp.features.subscription.api.response.PaymentResponse;
+import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface PaymentMapper {
+
+   PaymentResponse toResponse(PaymentEntity paymentEntity);
+
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PaymentRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PaymentRepository.java
@@ -3,6 +3,10 @@ package com.jame.dev.gymApp.features.subscription.infrastructure.persistence;
 import com.jame.dev.gymApp.domain.repository.CustomJpaRepository;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.NativeQuery;
+import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.List;
@@ -10,11 +14,22 @@ import java.util.Optional;
 
 public interface PaymentRepository extends CustomJpaRepository<PaymentEntity, Long> {
 
-    Optional<PaymentEntity> findByStripeSessionId(final String stripeSessionId);
+   Optional<PaymentEntity> findByStripeSessionId(final String stripeSessionId);
 
-    Optional<PaymentEntity> findByCustomer_User_EmailAndStatus(final String customerEmail, final PaymentStatus paymentStatus);
+   Optional<PaymentEntity> findByCustomer_User_EmailAndStatus(final String customerEmail, final PaymentStatus paymentStatus);
 
-    boolean existsByStripeSessionIdAndStatus(final String sessionId, final PaymentStatus paymentStatus);
+   boolean existsByStripeSessionIdAndStatus(final String sessionId, final PaymentStatus paymentStatus);
 
-    List<PaymentEntity> findAllByStatusAndCreatedAtBefore(final PaymentStatus status, final Instant before);
+   List<PaymentEntity> findAllByStatusAndCreatedAtBefore(final PaymentStatus status, final Instant before);
+
+   @NativeQuery(value = """
+      SELECT p.*
+      FROM payments p
+      WHERE p.customer_id = :customerId
+      """,
+      countQuery = """
+         SELECT COUNT(*) FROM payments p
+         WHERE p.customer_id = :customerId
+         """)
+   Page<PaymentEntity> findAll(@Param("customerId") final Long customerId, final Pageable pageable);
 }


### PR DESCRIPTION
# Description

This PR introduces a new entrypoint endpoint that allows authenticated users to retrieve a paginated list of all payments associated with a specific customer. It also adds the required query layer, response mapping, caching strategy, and supporting infrastructure to expose payment history efficiently while keeping cache consistency across payment and subscription lifecycle operations.

# Main Changes

- Added a new `PaymentUserController` exposing an endpoint to retrieve paginated payments for a customer.
- Implemented the `GetPaymentPageByCustomerId` use case and its service implementation.
- Added `PaymentResponse` DTO to expose payment information through the API.
- Introduced a dedicated `PaymentMapper` (MapStruct) to convert `PaymentEntity` into API responses.
- Extended the payment repository layer with paginated payment retrieval by customer.
- Added support for paginated payment queries in:
  - `PaymentQueryRepository`
  - `PaymentQueryJpaRepositoryAdapter`
  - `PaymentRepository`
- Implemented Redis caching for payment page queries.
- Added a dedicated `PAYMENTS` cache namespace.
- Updated payment and subscription mutation flows to properly evict payment caches when:
  - a payment is created;
  - a Stripe checkout is completed;
  - a subscription is finalized;
  - a subscription is soft deleted.
- Updated the subscriptions endpoint to retrieve the authenticated customer's subscriptions through the current authentication principal instead of requiring the customer email as a request parameter.
- Added automatic `createdAt` initialization through `@PrePersist` in `BaseEntity`.

# Minimal Changes

- Added the new `PAYMENTS` cache constant.
- Refactored cache eviction annotations to include payment cache invalidation.
- Improved cache configuration consistency across subscription services.
- Commented out the payment deactivation during subscription finalization to preserve payment records.
- Minor formatting and import cleanup across modified classes.

# Notes

- The new payments endpoint is protected by ownership validation to ensure customers can only access their own payment history.
- The native payment query currently filters by customer ID only; additional filters (status, date range, payment method, etc.) can be added in future iterations if needed.
- The change to initialize `createdAt` automatically at persistence time helps guarantee consistent timestamp generation across newly created entities.