### PR TITLE
Payment Metrics

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/application/model/CacheValues.java
+++ b/src/main/java/com/jame/dev/gymApp/application/model/CacheValues.java
@@ -6,6 +6,7 @@ public class CacheValues {
    public static final String SUBSCRIPTIONS = "subscriptions";
    public static final String USERS_INACTIVE = "users:inactive";
    public static final String PAYMENTS = "payments";
+   public static final String PAYMENT_METRICS = "payments:metrics";
 
    public static final String USER = "user";
    public static final String CUSTOMER = "customer";

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentSubscriberMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentSubscriberMetricsController.java
@@ -1,0 +1,48 @@
+package com.jame.dev.gymApp.features.metrics.api;
+
+import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
+import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsService;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequestMapping("/app/v1/subscribers/metrics")
+@RestController
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('USER')")
+public class PaymentSubscriberMetricsController {
+
+   private final PaymentMetricsService paymentMetricsService;
+
+   @PreAuthorize("@customerSecurity.isOwner(#customerId, authentication)")
+   @GetMapping("/{customerId}/investments")
+   public ResponseEntity<TotalInvestment> getTotalInvestment(
+      @PathVariable("customerId") long customerId
+   ) {
+      return ResponseEntity.ok(paymentMetricsService.getTotalExpend(customerId));
+   }
+
+   @PreAuthorize("@customerSecurity.isOwner(#customerId, authentication)")
+   @GetMapping("/{customerId}/resumes")
+   public ResponseEntity<AnnualResumeResponse> getAnnualResume(
+      @PathVariable("customerId") long customerId
+   ) {
+      return ResponseEntity.ok(paymentMetricsService.getAnnualResume(customerId));
+   }
+
+   @PreAuthorize("@customerSecurity.isOwner(#customerId, authentication)")
+   @GetMapping("/{customerId}/evolution")
+   public ResponseEntity<List<MonthTotal>> getMonthInvestmentEvolution(
+      @PathVariable("customerId") long customerId
+   ) {
+      return ResponseEntity.ok(paymentMetricsService.getInvestmentMonthEvolution(customerId));
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/AnnualResumeResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/AnnualResumeResponse.java
@@ -1,0 +1,14 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public record AnnualResumeResponse(
+   @JsonProperty("totalPaymentsMade") long totalPaymentsMade,
+   @JsonProperty("totalExpend") BigDecimal totalExpend,
+   @JsonProperty("average") BigDecimal average,
+   @JsonProperty("electronicPaymentsDone") long electronicPaymentsDone,
+   @JsonProperty("physicPaymentsDone") long physicPaymentsDone
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalInvestment.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalInvestment.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public record TotalInvestment(
+   @JsonProperty("total") BigDecimal total
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsService.java
@@ -1,0 +1,15 @@
+package com.jame.dev.gymApp.features.metrics.application.contract;
+
+import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+
+import java.util.List;
+
+public interface PaymentMetricsService {
+
+   TotalInvestment getTotalExpend(final long customerId);
+   AnnualResumeResponse getAnnualResume(final long customerId);
+   List<MonthTotal> getInvestmentMonthEvolution(final long customerId);
+
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
@@ -7,6 +7,7 @@ import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeD
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EarningMetricsApplicationService implements EarningMetricsService {
    private final EarningMetricsRepository repo;
 

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsSubscriberService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsSubscriberService.java
@@ -1,0 +1,52 @@
+package com.jame.dev.gymApp.features.metrics.application.service;
+
+import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
+import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsService;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+import com.jame.dev.gymApp.features.metrics.domain.repository.PaymentMetricsRepository;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CachePaymentMetricsValues;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentMetricsSubscriberService implements PaymentMetricsService {
+   private final PaymentMetricsRepository paymentMetricsRepository;
+
+   @Override
+   @Cacheable(
+      value = CachePaymentMetricsValues.INVESTMENT,
+      unless = "#result == null",
+      key = "#customerId"
+   )
+   public TotalInvestment getTotalExpend(long customerId) {
+      return paymentMetricsRepository.calculateTotalAmountExpended(customerId);
+   }
+
+   @Override
+   @Cacheable(
+      value = CachePaymentMetricsValues.RESUME,
+      unless = "#result == null",
+      key = "#customerId"
+   )
+   public AnnualResumeResponse getAnnualResume(long customerId) {
+      return paymentMetricsRepository.calculateAnnualResume(customerId);
+   }
+
+   @Override
+   @Cacheable(
+      value = CachePaymentMetricsValues.EVOLUTION,
+      unless = "#result == null || #result.isEmpty()",
+      key = "#customerId"
+   )
+   public List<MonthTotal> getInvestmentMonthEvolution(long customerId) {
+      return paymentMetricsRepository.calculatePaymentEvolutionAlongMonths(customerId);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
@@ -7,12 +7,14 @@ import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SubscriptionMetricsApplicationService implements SubscriptionMetricsService {
    private final SubscriptionMetricsRepository repo;
 

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/PaymentMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/PaymentMetricsRepository.java
@@ -1,0 +1,54 @@
+package com.jame.dev.gymApp.features.metrics.domain.repository;
+
+import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+import com.jame.dev.gymApp.features.metrics.infrastructure.query.MetricsRepository;
+import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
+import org.springframework.data.jpa.repository.NativeQuery;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PaymentMetricsRepository extends MetricsRepository<PaymentEntity, Long> {
+
+   @NativeQuery("""
+      SELECT
+          COALESCE(SUM(p.amount), 0) AS total
+      FROM payments p
+      WHERE p.customer_id = :customerId
+      """)
+   TotalInvestment calculateTotalAmountExpended(@Param("customerId") long customerId);
+
+
+   @NativeQuery("""
+      SELECT
+          COUNT(*) AS totalPaymentsMade,
+          COALESCE(SUM(p.amount), 0) AS totalExpend,
+          COALESCE(ROUND(AVG(p.amount), 2), 0) AS avergare,
+          COUNT(*) FILTER ( WHERE p.payment_method = 'ELECTRONIC' ) as electronicPaymentsDone,
+          COUNT(*) FILTER ( WHERE p.payment_method = 'PHYSIC' ) as physicPaymentsDone
+      FROM payments p
+      WHERE
+          p.customer_id = :customerId AND
+          p.created_at >= DATE_TRUNC('year', CURRENT_DATE) AND
+          p.created_at < date_trunc('year', CURRENT_DATE) + INTERVAL '1 year'
+      """)
+   AnnualResumeResponse calculateAnnualResume(@Param("customerId") long customerId);
+
+   @NativeQuery("""
+      SELECT
+          TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
+          COALESCE(SUM(p.amount), 0) AS total
+      FROM generate_series(1, 12) AS m(month_number)
+      LEFT JOIN payments p
+          ON EXTRACT(MONTH FROM p.created_at) = m.month_number
+          AND p.customer_id = :customerId
+          AND p.amount > 0
+          AND p.created_at >= DATE_TRUNC('year', CURRENT_DATE)
+          AND p.created_at < DATE_TRUNC('year', CURRENT_DATE) + INTERVAL '1 year'
+      GROUP BY m.month_number
+      ORDER BY m.month_number
+      """)
+   List<MonthTotal> calculatePaymentEvolutionAlongMonths(@Param("customerId") long customerId);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictPaymentMetrics.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictPaymentMetrics.java
@@ -1,0 +1,19 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.annotations;
+
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CachePaymentMetricsValues;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Caching(evict = {
+   @CacheEvict(value = CachePaymentMetricsValues.INVESTMENT, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CachePaymentMetricsValues.EVOLUTION, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CachePaymentMetricsValues.RESUME, allEntries = true, cacheManager = "redisCacheManager")
+})
+public @interface EvictPaymentMetrics {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CachePaymentMetricsValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CachePaymentMetricsValues.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.cache;
+
+public class CachePaymentMetricsValues {
+   public static final String INVESTMENT = "payments:metrics:investment";
+   public static final String RESUME = "payments:metrics:resume";
+   public static final String EVOLUTION = "payments:metrics:evolution";
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/query/MetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/query/MetricsRepository.java
@@ -3,9 +3,7 @@ package com.jame.dev.gymApp.features.metrics.infrastructure.query;
 import lombok.NonNull;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 @NoRepositoryBean
-@Transactional(readOnly = true)
 public interface MetricsRepository<T, ID> extends Repository<@NonNull T, @NonNull ID> {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/PaymentUserController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/PaymentUserController.java
@@ -12,10 +12,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/app/v1/subscribers/payments")
@@ -29,12 +26,16 @@ public class PaymentUserController {
    @GetMapping("/{customerId}/customers")
    public ResponseEntity<Page<PaymentResponse>> getPaymentPageByCustomerId(
       @Minimum
-      @PathVariable("customerId") final long customerId,
+      @PathVariable("customerId")
+      final long customerId,
+      @RequestParam(name = "search", required = false)
+      final String search,
       @PageableDefault(
          sort = "id",
          direction = Sort.Direction.DESC
-      ) final Pageable pageable) {
-      final var pageDto = getPaymentPageByCustomerId.getPageByCustomerId(customerId, pageable);
+      )
+      final Pageable pageable) {
+      final var pageDto = getPaymentPageByCustomerId.getPageByCustomerId(customerId, search, pageable);
       final Page<PaymentResponse> page = new PageImpl<>(pageDto.content(), pageable, pageDto.totalElements());
       return ResponseEntity.ok(page);
    }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/response/PaymentResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/response/PaymentResponse.java
@@ -5,13 +5,12 @@ import com.jame.dev.gymApp.features.subscription.domain.model.PaymentMethod;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 
 public record PaymentResponse(
    @JsonProperty("id") Long id,
    @JsonProperty("amount") BigDecimal amount,
    @JsonProperty("status") PaymentStatus status,
    @JsonProperty("paymentMethod") PaymentMethod paymentMethod,
-   @JsonProperty("createdAt") Instant createdAt
+   @JsonProperty("createdAt") String createdAt
 ) {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
@@ -2,6 +2,7 @@ package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 
 import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.domain.exception.EntityNotFoundException;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictPaymentMetrics;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CompletedCheckoutUseCase;
 import com.jame.dev.gymApp.features.subscription.domain.event.CompletedCheckoutEvent;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
@@ -36,6 +37,7 @@ public class CompletedCheckoutUseCaseService implements CompletedCheckoutUseCase
          @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true)
       }
    )
+   @EvictPaymentMetrics
    public void execute(CompletedCheckoutEvent event) {
       final PaymentEntity paymentEntity = paymentQueryRepository.findByStripeSessionId(event.stripeSessionId())
          .orElseThrow(() -> new EntityNotFoundException("Payment not found"));

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreatePaymentUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreatePaymentUseCaseService.java
@@ -1,6 +1,7 @@
 package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 
 import com.jame.dev.gymApp.application.model.CacheValues;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictPaymentMetrics;
 import com.jame.dev.gymApp.features.subscription.api.request.PaymentRequest;
 import com.jame.dev.gymApp.features.subscription.application.support.factory.PaymentFactory;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreatePaymentUseCase;
@@ -25,6 +26,7 @@ public class CreatePaymentUseCaseService implements CreatePaymentUseCase {
    @Override
    @Transactional
    @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true)
+   @EvictPaymentMetrics
    public void create(PaymentRequest paymentRequest) {
       final SubscriptionEntity subscriptionEntity = subscriptionQueryRepository.findById(paymentRequest.subscriptionId())
          .orElseThrow(() -> new SubscriptionNotFoundException("Subscription not found for id: " + paymentRequest.subscriptionId()));

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetPaymentPageByCustomerIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/query/GetPaymentPageByCustomerIdUseCaseService.java
@@ -7,6 +7,7 @@ import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetP
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
 import com.jame.dev.gymApp.features.subscription.domain.repository.PaymentQueryRepository;
 import com.jame.dev.gymApp.features.subscription.infrastructure.payment.mapper.PaymentMapper;
+import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetPaymentPageByCustomerIdUseCaseService implements GetPaymentPageByCustomerId {
    private final PaymentQueryRepository paymentQueryRepository;
    private final PaymentMapper paymentMapper;
+   private final SortPropertyResolver paymentSortResolver;
 
    @Override
    @Cacheable(
@@ -27,8 +29,9 @@ public class GetPaymentPageByCustomerIdUseCaseService implements GetPaymentPageB
       keyGenerator = "pageKeyGenerator",
       unless = "#result == null || #result.content.isEmpty()"
    )
-   public PageDto<PaymentResponse> getPageByCustomerId(Long customerId, Pageable pageable) {
-      final Page<PaymentEntity> entityPage = paymentQueryRepository.findPaymentPage(customerId, pageable);
+   public PageDto<PaymentResponse> getPageByCustomerId(Long customerId, String search, Pageable pageable) {
+      final Pageable pageableWrapped = paymentSortResolver.resolve(pageable);
+      final Page<PaymentEntity> entityPage = paymentQueryRepository.findPaymentPage(customerId, search, pageableWrapped);
       final var content = entityPage.getContent().stream()
          .map(paymentMapper::toResponse)
          .toList();

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetPaymentPageByCustomerId.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/usecases/query/GetPaymentPageByCustomerId.java
@@ -5,5 +5,5 @@ import com.jame.dev.gymApp.features.subscription.api.response.PaymentResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface GetPaymentPageByCustomerId {
-   PageDto<PaymentResponse> getPageByCustomerId(final Long customerId, final Pageable pageable);
+   PageDto<PaymentResponse> getPageByCustomerId(final Long customerId, final String search, final Pageable pageable);
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/PaymentEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/PaymentEntity.java
@@ -16,7 +16,8 @@ import java.math.BigDecimal;
 @Builder
 @Table(name = "payments", indexes = {
    @Index(name = "idx_payment_stripe_session_id", columnList = "stripe_session_id"),
-   @Index(name = "idx_payment_customer_id", columnList = "customer_id")
+   @Index(name = "idx_payment_customer_id", columnList = "customer_id"),
+   @Index(name= "idx_payment_created_at", columnList = "created_at")
 })
 @SQLDelete(sql = "UPDATE payments SET active = false, deleted_at = NOW() WHERE id = ?")
 public class PaymentEntity extends BaseEntity {

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/PaymentQueryRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/repository/PaymentQueryRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 public interface PaymentQueryRepository {
 
-   Page<PaymentEntity> findPaymentPage(final Long customerId, final Pageable pageable);
+   Page<PaymentEntity> findPaymentPage(final Long customerId, final String search, final Pageable pageable);
 
     Optional<PaymentEntity> findById(final long id);
 

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/PaymentQueryJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/adapter/PaymentQueryJpaRepositoryAdapter.java
@@ -19,8 +19,8 @@ public class PaymentQueryJpaRepositoryAdapter implements PaymentQueryRepository 
     private final PaymentRepository paymentRepository;
 
    @Override
-   public Page<PaymentEntity> findPaymentPage(Long customerId, Pageable pageable) {
-      return paymentRepository.findAll(customerId, pageable);
+   public Page<PaymentEntity> findPaymentPage(Long customerId, String search, Pageable pageable) {
+      return paymentRepository.findAll(customerId, search, pageable);
    }
 
    @Override

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/payment/mapper/PaymentMapper.java
@@ -4,10 +4,24 @@ import com.jame.dev.gymApp.features.subscription.api.response.PaymentResponse;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Objects;
 
 @Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
 public interface PaymentMapper {
 
+   @Mapping(target = "createdAt", expression = "java(mapInstantToHumanReadable(paymentEntity))")
    PaymentResponse toResponse(PaymentEntity paymentEntity);
 
+   default String mapInstantToHumanReadable(PaymentEntity paymentEntity) {
+      if (Objects.isNull(paymentEntity.getCreatedAt())) return "No Timestamp";
+      final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEEE MMMM, d yyyy HH:mm:ss")
+         .withZone(ZoneId.systemDefault())
+         .withLocale(Locale.US);
+      return formatter.format(paymentEntity.getCreatedAt());
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PaymentRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/persistence/PaymentRepository.java
@@ -25,11 +25,27 @@ public interface PaymentRepository extends CustomJpaRepository<PaymentEntity, Lo
    @NativeQuery(value = """
       SELECT p.*
       FROM payments p
-      WHERE p.customer_id = :customerId
+      WHERE p.customer_id = :customerId AND
+      (
+        :search IS NULL OR TRIM(:search) = '' OR
+        CAST(p.amount AS TEXT) ILIKE CONCAT('%', :search, '%') OR
+        CAST(p.payment_method AS TEXT) ILIKE CONCAT('%', :search , '%') OR
+        CAST(p.status AS TEXT) ILIKE CONCAT('%', :search , '%')
+      )
       """,
       countQuery = """
-         SELECT COUNT(*) FROM payments p
-         WHERE p.customer_id = :customerId
+               SELECT COUNT(*) FROM payments p
+               WHERE p.customer_id = :customerId AND
+            (
+              :search IS NULL OR TRIM(:search) = '' OR
+              CAST(p.amount AS TEXT) ILIKE CONCAT('%', :search, '%') OR
+              CAST(p.payment_method AS TEXT) ILIKE CONCAT('%', :search , '%') OR
+              CAST(p.status AS TEXT) ILIKE CONCAT('%', :search , '%')
+            )
          """)
-   Page<PaymentEntity> findAll(@Param("customerId") final Long customerId, final Pageable pageable);
+   Page<PaymentEntity> findAll(
+      @Param("customerId") final Long customerId,
+      @Param("search") final String search,
+      final Pageable pageable
+   );
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/model/PaymentSortProperty.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/model/PaymentSortProperty.java
@@ -1,0 +1,19 @@
+package com.jame.dev.gymApp.features.subscription.infrastructure.sort.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentSortProperty {
+
+   ID("id", "id"),
+   STATUS("status", "status"),
+   PAYMENT_METHOD("method", "payment_method"),
+   AMOUNT("amount", "amount"),
+   CREATED_AT("createdAt", "created_at"),
+   ;
+
+   private final String apiProperty;
+   private final String entityProperty;
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/model/SubscriptionSortProperty.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/model/SubscriptionSortProperty.java
@@ -1,4 +1,4 @@
-package com.jame.dev.gymApp.features.subscription.domain.model;
+package com.jame.dev.gymApp.features.subscription.infrastructure.sort.model;
 
 import lombok.Getter;
 

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/resolver/PaymentSortResolver.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/resolver/PaymentSortResolver.java
@@ -1,0 +1,29 @@
+package com.jame.dev.gymApp.features.subscription.infrastructure.sort.resolver;
+
+
+import com.jame.dev.gymApp.features.subscription.infrastructure.sort.model.PaymentSortProperty;
+import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
+import com.jame.dev.gymApp.infrastructure.sort.SortResolver;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component("paymentSortResolver")
+public class PaymentSortResolver implements SortPropertyResolver {
+   private static final Map<String, String> PROPERTY_MAP = Arrays.stream(
+      PaymentSortProperty.values()
+   ).collect(
+      Collectors.toMap(
+         PaymentSortProperty::getApiProperty,
+         PaymentSortProperty::getEntityProperty
+      )
+   );
+
+   @Override
+   public Pageable resolve(Pageable pageable) {
+      return SortResolver.resolveSortPropertiesFrom(pageable, PROPERTY_MAP);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/resolver/SubscriptionSortApplicationResolver.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/infrastructure/sort/resolver/SubscriptionSortApplicationResolver.java
@@ -1,0 +1,26 @@
+package com.jame.dev.gymApp.features.subscription.infrastructure.sort.resolver;
+
+import com.jame.dev.gymApp.features.subscription.infrastructure.sort.model.SubscriptionSortProperty;
+import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
+import com.jame.dev.gymApp.infrastructure.sort.SortResolver;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component("subSortAppResolver")
+public class SubscriptionSortApplicationResolver implements SortPropertyResolver {
+   private static final Map<String, String> PROPERTY_MAP = Arrays.stream(
+      SubscriptionSortProperty.values()
+   ).collect(Collectors.toMap(
+      SubscriptionSortProperty::getApiProperty,
+      SubscriptionSortProperty::getEntityProperty
+   ));
+
+   @Override
+   public Pageable resolve(Pageable pageable) {
+      return SortResolver.resolveSortPropertiesFrom(pageable, PROPERTY_MAP);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/RedisConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/RedisConfig.java
@@ -29,6 +29,8 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
 
 @Slf4j
 @Configuration
@@ -118,23 +120,7 @@ public class RedisConfig {
       scanner.findCandidateComponents("com.jame.dev.gymApp").forEach(beanDefinition -> {
          try {
             Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
-            if (clazz.isRecord()) {
-               mapper.addMixIn(clazz, DefaultMixInDto.class);
-            }
-         } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e.getMessage(), e);
-         }
-      });
-   }
-
-   private void registerMixIns(ObjectMapper mapper, String basePackage) {
-      ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
-      scanner.addIncludeFilter(new AssignableTypeFilter(Object.class));
-
-      scanner.findCandidateComponents(basePackage).forEach(beanDefinition -> {
-         try {
-            Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
-            if (clazz.isRecord()) {
+            if (clazz.isRecord() || clazz.isAssignableFrom(Map.class) || clazz.isAssignableFrom(Collection.class)) {
                mapper.addMixIn(clazz, DefaultMixInDto.class);
             }
          } catch (ClassNotFoundException e) {

--- a/src/main/java/com/jame/dev/gymApp/infrastructure/sort/SortResolver.java
+++ b/src/main/java/com/jame/dev/gymApp/infrastructure/sort/SortResolver.java
@@ -1,30 +1,19 @@
-package com.jame.dev.gymApp.features.subscription.application.support.resolver;
+package com.jame.dev.gymApp.infrastructure.sort;
 
-import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionSortProperty;
-import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-@Component("subSortAppResolver")
-public class SubscriptionSortApplicationResolver implements SortPropertyResolver {
-   private static final Map<String, String> PROPERTY_MAP = Arrays.stream(
-      SubscriptionSortProperty.values()
-   ).collect(Collectors.toMap(
-      SubscriptionSortProperty::getApiProperty,
-      SubscriptionSortProperty::getEntityProperty
-   ));
+public class SortResolver {
 
-   @Override
-   public Pageable resolve(Pageable pageable) {
+   public static Pageable resolveSortPropertiesFrom(
+      final Pageable pageable,
+      final Map<String, String> PROPERTY_MAP
+   ) {
       if (pageable.getSort().isUnsorted()) return pageable;
-      System.out.println(PROPERTY_MAP);
       final List<Sort.Order> resolverOrders = pageable.getSort()
          .stream()
          .map(o -> {


### PR DESCRIPTION
# Description

This PR introduces payment metrics endpoints for authenticated subscribers (`USER` role), allowing users to visualize their payment activity through investment summaries, annual statistics, and monthly spending evolution. Additionally, it improves cache management by introducing dedicated payment metrics caches with automatic eviction after payment mutations, while enhancing payment listing capabilities with search and flexible sorting support.

# Main Changes

- Added a new **Payment Metrics** module for subscribers, including:
  - Total investment endpoint.
  - Annual payment summary endpoint.
  - Monthly payment evolution endpoint.
- Restricted all payment metrics endpoints to authenticated users with the `USER` role and ownership validation through `customerSecurity`.
- Implemented `PaymentMetricsService` and repository layer with native queries for:
  - Total amount invested.
  - Annual payment statistics.
  - Monthly payment evolution.
- Added Redis cache support for payment metrics:
  - Investment.
  - Annual resume.
  - Monthly evolution.
- Introduced the `@EvictPaymentMetrics` annotation to automatically invalidate payment metrics caches after payment creation and completed checkout operations.
- Marked metrics services as `@Transactional(readOnly = true)` to optimize read operations.
- Added search support to subscriber payment pagination, allowing filtering by:
  - Payment amount.
  - Payment method.
  - Payment status.
- Implemented payment-specific sort property resolution using a reusable sorting infrastructure.
- Added a database index on `payments.created_at` to improve sorting and analytical query performance.
- Enhanced Redis serialization configuration to support caching collections and maps in addition to Java records.

# Minimal Changes

- Refactored the generic metrics repository by removing the global transactional annotation.
- Refactored sorting logic into a reusable `SortResolver` utility shared across modules.
- Moved subscription sort properties into the infrastructure layer.
- Updated `PaymentResponse.createdAt` from `Instant` to a human-readable formatted `String`.
- Added a custom date formatter in `PaymentMapper` for payment timestamps.
- Minor controller and method signature adjustments to support search parameters.
- Added new cache constants for payment metrics.

# Notes

- Payment metrics caches are automatically invalidated after payment creation and successful checkout completion, ensuring users always receive fresh analytical data.
- The new sorting infrastructure can be reused by additional modules requiring API-to-database sort property mapping.
- Current payment search is limited to amount, payment method, and payment status. Future iterations could extend filtering to payment date ranges, subscriptions, or full-text search.
- Additional metrics such as payment trends, average monthly spending, payment method distribution, and year-over-year comparisons can be incorporated using the current architecture with minimal changes.