### PR TITLE
Metrics cache compatibility

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/EarningMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/EarningMetricsController.java
@@ -1,7 +1,8 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
+import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,9 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/app/v1/administration/metrics/earnings")
@@ -20,12 +19,12 @@ public class EarningMetricsController {
    private final EarningMetricsService service;
 
    @GetMapping("/total")
-   public ResponseEntity<Map<String, BigDecimal>> getTotalEarnings() {
-      return ResponseEntity.ok(Map.of("total", service.getTotal()));
+   public ResponseEntity<TotalEarned> getTotalEarnings() {
+      return ResponseEntity.ok(service.getTotal());
    }
 
    @GetMapping("/months")
-   public ResponseEntity<Map<Integer, List<MonthTotal>>> getTotalPerMonth() {
+   public ResponseEntity<List<TotalPerMonthResponse>> getTotalPerMonth() {
       return ResponseEntity.ok(service.getTotalPerMonth());
    }
 

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
@@ -1,10 +1,10 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
+import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/app/v1/administration/metrics/subs")
@@ -23,15 +22,13 @@ public class SubscriptionMetricsController {
    private final SubscriptionMetricsService service;
 
    @GetMapping("/totals")
-   public ResponseEntity<Map<String, Long>> getTotalSubscriptions(){
-      final long total = service.getTotalSubscriptions();
-      return buildResponseMap(total);
+   public ResponseEntity<TotalSubscriptions> getTotalSubscriptions(){
+      return  ResponseEntity.ok(service.getTotalSubscriptions());
    }
 
    @GetMapping("/{date}/before")
-   public ResponseEntity<Map<String, Long>> getTotalBefore(@PathVariable("date") final LocalDate date){
-      final long total = service.getSubscriptionsBefore(date);
-      return buildResponseMap(total);
+   public ResponseEntity<TotalSubscriptions> getTotalBefore(@PathVariable("date") final LocalDate date){
+      return ResponseEntity.ok(service.getSubscriptionsBefore(date));
    }
 
    @GetMapping("/memberships")
@@ -42,11 +39,5 @@ public class SubscriptionMetricsController {
    @GetMapping("/months")
    public ResponseEntity<List<SubsPerMonthDto>> getSubsPerMonth() {
       return ResponseEntity.ok(service.getSubscriptionsPerMonth());
-   }
-
-   private ResponseEntity<Map<String, Long>> buildResponseMap(long total){
-      return ResponseEntity.ok()
-              .contentType(MediaType.APPLICATION_JSON)
-              .body(Map.of("total", total));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalEarned.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalEarned.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public record TotalEarned(
+   @JsonProperty("total") BigDecimal total
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalPerMonthResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalPerMonthResponse.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+
+import java.util.List;
+
+public record TotalPerMonthResponse(
+   @JsonProperty("year") Integer year,
+   @JsonProperty("monthsTotal") List<MonthTotal> monthTotals
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalSubscriptions.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/TotalSubscriptions.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TotalSubscriptions(
+   @JsonProperty("total") long total
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EarningMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EarningMetricsService.java
@@ -1,16 +1,15 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 
 public interface EarningMetricsService {
-   BigDecimal getTotal();
+   TotalEarned getTotal();
 
-   Map<Integer, List<MonthTotal>> getTotalPerMonth();
+   List<TotalPerMonthResponse> getTotalPerMonth();
 
    List<TotalPerMembershipTypeDto> getTotalPerMembershipType();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
@@ -1,5 +1,6 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
+import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import lombok.NonNull;
@@ -8,9 +9,9 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface SubscriptionMetricsService {
-   long getTotalSubscriptions();
+   TotalSubscriptions getTotalSubscriptions();
 
-   long getSubscriptionsBefore(@NonNull final LocalDate date);
+   TotalSubscriptions getSubscriptionsBefore(@NonNull final LocalDate date);
 
    List<SubsPerMonthDto> getSubscriptionsPerMonth();
 

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
@@ -1,17 +1,19 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
-import com.jame.dev.gymApp.features.metrics.domain.repository.EarningMetricsRepository;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth;
+import com.jame.dev.gymApp.features.metrics.domain.repository.EarningMetricsRepository;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEarningMetricValues;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,25 +23,40 @@ public class EarningMetricsApplicationService implements EarningMetricsService {
    private final EarningMetricsRepository repo;
 
    @Override
-   public BigDecimal getTotal() {
+   @Cacheable(
+      value = CacheEarningMetricValues.EARNING_TOTAL
+   )
+   public TotalEarned getTotal() {
       return repo.calculateTotalEarned();
    }
 
    @Override
-   public Map<Integer, List<MonthTotal>> getTotalPerMonth() {
+   @Cacheable(
+      value = CacheEarningMetricValues.EARNING_PER_MONTH,
+      unless = "#result == null || #result.isEmpty()"
+   )
+   public List<TotalPerMonthResponse> getTotalPerMonth() {
       final List<TotalPerMonth> totalPerMonthDtoList = repo.calculateTotalPerMonth();
       return totalPerMonthDtoList.stream()
-              .collect(Collectors.groupingBy(
-                      TotalPerMonth::year,
-                      Collectors.mapping(
-                              dto ->
-                                      new MonthTotal(dto.month(), dto.total()),
-                              Collectors.toUnmodifiableList()
-                      )
-              ));
+         .collect(Collectors.groupingBy(
+            TotalPerMonth::year,
+            Collectors.mapping(
+               dto ->
+                  new MonthTotal(dto.month(), dto.total()),
+               Collectors.toUnmodifiableList()
+            )
+         ))
+         .entrySet()
+         .stream()
+         .map(entry -> new TotalPerMonthResponse(entry.getKey(), entry.getValue()))
+         .toList();
    }
 
    @Override
+   @Cacheable(
+      value = CacheEarningMetricValues.EARNING_MEMBERSHIP_TYPE,
+      unless = "#result == null || #result.isEmpty()"
+   )
    public List<TotalPerMembershipTypeDto> getTotalPerMembershipType() {
       final List<TotalPerMembershipTypeDto> dtoList = repo.calculateTotalPerMembership();
       return dtoList.isEmpty() ? List.of() : dtoList;

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
@@ -1,11 +1,14 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
-import com.jame.dev.gymApp.features.metrics.domain.repository.SubscriptionMetricsRepository;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
+import com.jame.dev.gymApp.features.metrics.domain.repository.SubscriptionMetricsRepository;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheSubsMetricsValues;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,27 +22,34 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
    private final SubscriptionMetricsRepository repo;
 
    @Override
-   public long getTotalSubscriptions() {
-      return repo.countDistinctByActiveTrueAndFinishedFalse();
+   @Cacheable(
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL, unless = "#result == null"
+   )
+   public TotalSubscriptions getTotalSubscriptions() {
+      return repo.countAllSubscriptionDistinct();
    }
 
    @Override
-   public long getSubscriptionsBefore(@NonNull LocalDate date) {
+   @Cacheable(
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_BEFORE, unless = "#result == null"
+   )
+   public TotalSubscriptions getSubscriptionsBefore(@NonNull LocalDate date) {
       return repo.countByStartDateBefore(date);
    }
 
-
    @Override
+   @Cacheable(
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH, unless = "#result == null || #result.isEmpty()"
+   )
    public List<SubsPerMonthDto> getSubscriptionsPerMonth() {
-      return returnList(repo.countSubsByMonth());
+      return repo.countSubsByMonth();
    }
 
    @Override
+   @Cacheable(
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MEMBERSHIP, unless = "#result == null || #result.isEmpty()"
+   )
    public List<SubsPerMembership> getSubscriptionsPerMembership() {
-       return returnList(repo.countSubsByMembership());
-   }
-
-   private <T> List<T> returnList(List<T> list) {
-      return (list.isEmpty()) ? List.of() : list;
+      return repo.countSubsByMembership();
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/SubsPerMembership.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/SubsPerMembership.java
@@ -1,10 +1,9 @@
 package com.jame.dev.gymApp.features.metrics.domain.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 
 public record SubsPerMembership(
-        @JsonProperty("membership") Membership membership,
+        @JsonProperty("membership") String membership,
         @JsonProperty("subsCount") long subsCount
 ) {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/TotalPerMembershipTypeDto.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/TotalPerMembershipTypeDto.java
@@ -1,12 +1,11 @@
 package com.jame.dev.gymApp.features.metrics.domain.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 
 import java.math.BigDecimal;
 
 public record TotalPerMembershipTypeDto(
-        @JsonProperty("membership") Membership membership,
+        @JsonProperty("membership") String membership,
         @JsonProperty("total") BigDecimal total
 ) {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EarningMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EarningMetricsRepository.java
@@ -1,48 +1,55 @@
 package com.jame.dev.gymApp.features.metrics.domain.repository;
 
-import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth;
 import com.jame.dev.gymApp.features.metrics.infrastructure.query.MetricsRepository;
-import org.springframework.data.jpa.repository.Query;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import org.springframework.data.jpa.repository.NativeQuery;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 public interface EarningMetricsRepository extends MetricsRepository<SubscriptionEntity, Long> {
 
-   @Query("""
-           SELECT COALESCE(SUM(p.price), 0)
-           FROM SubscriptionEntity s
-           JOIN s.pricing p
+   @NativeQuery("""
+           SELECT
+             COALESCE(SUM(mp.price), 0) as total
+           FROM subscriptions s
+           INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
+           WHERE s.paid = true
            """)
-   BigDecimal calculateTotalEarned();
+   TotalEarned calculateTotalEarned();
 
-   @Query("""
-           SELECT new com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth(
-               CAST(YEAR(sp.startPeriod) AS integer) AS year,
-               CAST(FUNCTION('to_char', sp.startPeriod, 'FMMonth') AS string) AS month,
-               CAST(COALESCE(SUM(p.price), 0) AS big_decimal) as total
-           )
-           FROM SubscriptionEntity s
-           JOIN s.subscriptionPeriods sp
-           JOIN s.pricing p
+   @NativeQuery("""
+           SELECT
+               CAST(EXTRACT(YEAR FROM p.start_period) AS integer) AS year,
+               CAST(TO_CHAR(p.start_period, 'FMMon') AS varchar(4)) AS month,
+               COALESCE(SUM(mp.price), 0) as total
+           FROM subscriptions s
+           INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
+           INNER JOIN periods p ON p.id = sp.period_id
+           INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
+           WHERE s.paid = true
            GROUP BY
-               YEAR(sp.startPeriod),
-               FUNCTION('to_char', sp.startPeriod, 'FMMonth'),
-               MONTH(sp.startPeriod)
+               EXTRACT(YEAR FROM p.start_period),
+               EXTRACT(MONTH FROM p.start_period),
+               TO_CHAR(p.start_period, 'FMMon')
            ORDER BY
-               YEAR(sp.startPeriod),
-               MONTH(sp.startPeriod)
-           """)
+               EXTRACT(YEAR FROM p.start_period),
+               EXTRACT(MONTH FROM p.start_period)
+      """)
    List<TotalPerMonth> calculateTotalPerMonth();
 
-   @Query("""
-           SELECT m.membership, COALESCE(SUM(p.price), 0)
-           FROM SubscriptionEntity s
-           JOIN s.pricing p
-           JOIN s.pricing.memberShipEntity m
+   @NativeQuery("""
+           SELECT
+              m.membership as membership,
+              COALESCE(SUM(mp.price), 0) as total
+           FROM subscriptions s
+           INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
+           INNER JOIN memberships m ON m.id = mp.membership_id
+           WHERE s.paid = true
            GROUP BY m.membership
+           ORDER BY m.membership DESC
            """)
    List<TotalPerMembershipTypeDto> calculateTotalPerMembership();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
@@ -1,50 +1,54 @@
 package com.jame.dev.gymApp.features.metrics.domain.repository;
 
-import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import com.jame.dev.gymApp.features.metrics.infrastructure.query.MetricsRepository;
-import org.springframework.data.jpa.repository.Query;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import org.springframework.data.jpa.repository.NativeQuery;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface SubscriptionMetricsRepository extends
-        MetricsRepository<SubscriptionEntity, Long> {
+   MetricsRepository<SubscriptionEntity, Long> {
 
-   long countDistinctByActiveTrueAndFinishedFalse();
+   @NativeQuery("SELECT DISTINCT COUNT(*) AS total FROM subscriptions WHERE paid = true")
+   TotalSubscriptions countAllSubscriptionDistinct();
 
-   @Query("""
-           SELECT COUNT(s) FROM SubscriptionEntity s
-           WHERE s.active = true
-           AND EXISTS (
-               SELECT 1 FROM s.subscriptionPeriods p
-               WHERE p.startPeriod < :now
-           )
-           """)
-   long countByStartDateBefore(@Param("now") LocalDate now);
+   @NativeQuery("""
+      SELECT
+         DISTINCT COUNT(s) as total
+      FROM subscriptions s
+      INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
+      INNER JOIN periods p ON p.id = sp.period_id
+      WHERE s.paid = true AND p.start_period <= :now
+      """)
+   TotalSubscriptions countByStartDateBefore(@Param("now") LocalDate now);
 
-   @Query("""
-           SELECT new com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto(
-               CAST(FUNCTION('TO_CHAR', p.startPeriod, 'FMMonth') AS string) AS month,
-               COUNT(s) as total
-           )
-           FROM SubscriptionEntity s
-           JOIN s.subscriptionPeriods p
-           WHERE s.active = true AND s.finished = false
-           GROUP BY FUNCTION('TO_CHAR', p.startPeriod, 'FMMonth')
-           ORDER BY MIN(p.startPeriod)
-           """)
+   @NativeQuery("""
+      SELECT
+          CAST(TO_CHAR(p.start_period, 'FMMon') AS varchar(4)) AS month,
+          COUNT(s) AS total
+      FROM subscriptions s
+      LEFT JOIN subscription_periods sp ON sp.subscription_id = s.id
+      INNER JOIN periods p ON p.id = sp.period_id
+      WHERE s.paid = true
+      GROUP BY TO_CHAR(p.start_period, 'FMMon')
+      ORDER BY MIN(p.start_period)
+      """)
    List<SubsPerMonthDto> countSubsByMonth();
 
-   @Query("""
-           SELECT
-           m.membership, COUNT(s)
-           FROM SubscriptionEntity s
-           JOIN s.pricing.memberShipEntity m
-           GROUP BY m.membership
-           ORDER BY m.membership ASC
-           """)
+   @NativeQuery("""
+      SELECT
+        CAST(m.membership as varchar(15)) AS membership,
+        COUNT(s) AS subsCount
+      FROM subscriptions s
+      INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
+      INNER JOIN memberships m ON m.id = mp.membership_id
+      GROUP BY m.membership
+      ORDER BY m.membership DESC
+      """)
    List<SubsPerMembership> countSubsByMembership();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictEarningMetrics.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictEarningMetrics.java
@@ -1,0 +1,20 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.annotations;
+
+
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEarningMetricValues;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Caching(evict = {
+   @CacheEvict(value = CacheEarningMetricValues.EARNING_TOTAL, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheEarningMetricValues.EARNING_PER_MONTH, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheEarningMetricValues.EARNING_MEMBERSHIP_TYPE, allEntries = true, cacheManager = "redisCacheManager")
+})
+public @interface EvictEarningMetrics {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictSubscriptionMetrics.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictSubscriptionMetrics.java
@@ -1,0 +1,20 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.annotations;
+
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheSubsMetricsValues;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Caching(evict = {
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_BEFORE, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MEMBERSHIP, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH, allEntries = true, cacheManager = "redisCacheManager")
+})
+public @interface EvictSubscriptionMetrics {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheEarningMetricValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheEarningMetricValues.java
@@ -1,0 +1,7 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.cache;
+
+public class CacheEarningMetricValues {
+   public final static String EARNING_TOTAL = "earnings:total";
+   public final static String EARNING_PER_MONTH = "earnings:per:month";
+   public final static String EARNING_MEMBERSHIP_TYPE = "earnings:membership";
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheSubsMetricsValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheSubsMetricsValues.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.cache;
+
+public class CacheSubsMetricsValues {
+   public static final String SUBSCRIPTION_TOTAL = "subscriptions:metrics:total";
+   public static final String SUBSCRIPTION_TOTAL_BEFORE = "subscriptions:metrics:total:before";
+   public static final String SUBSCRIPTION_TOTAL_PER_MONTH = "subscriptions:metrics:total:month";
+   public static final String SUBSCRIPTION_TOTAL_PER_MEMBERSHIP = "subscriptions:metrics:total:memberships";
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreateSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreateSubscriptionUseCaseService.java
@@ -7,6 +7,8 @@ import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException
 import com.jame.dev.gymApp.features.customer.domain.exception.CustomerNotFoundException;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
 import com.jame.dev.gymApp.features.customer.domain.repository.CustomerQueryRepository;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictEarningMetrics;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictSubscriptionMetrics;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
@@ -39,6 +41,8 @@ public class CreateSubscriptionUseCaseService implements CreateSubscriptionUseCa
     @Override
     @Transactional
     @CacheEvict(value = SUBSCRIPTIONS, allEntries = true)
+    @EvictEarningMetrics
+    @EvictSubscriptionMetrics
     @AuditLog(
         action = AuditLogAction.INSERT,
         entityType = AuditLogEntityType.SUBSCRIPTION,

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
@@ -12,6 +12,7 @@ import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -24,9 +25,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTION;
-import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTIONS;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -37,17 +35,8 @@ public class FinalizeSubscriptionUseCaseService implements FinalizeSubscriptionU
 
    @Override
    @Transactional
+   @CacheEvictSubscriptions
    @Caching(evict = {
-      @CacheEvict(
-         value = SUBSCRIPTIONS,
-         allEntries = true,
-         beforeInvocation = true,
-         cacheManager = "redisCacheManager"),
-      @CacheEvict(
-         value = SUBSCRIPTION,
-         key = "#id",
-         cacheManager = "redisCacheManager"
-      ),
       @CacheEvict(
          value = CacheValues.PAYMENTS, allEntries = true,
          cacheManager = "redisCacheManager"

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/RenewSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/RenewSubscriptionUseCaseService.java
@@ -3,6 +3,8 @@ package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictEarningMetrics;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictSubscriptionMetrics;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
@@ -31,6 +33,8 @@ public class RenewSubscriptionUseCaseService implements RenewSubscriptionUseCase
     @Override
     @Transactional
     @CacheEvictSubscriptions
+    @EvictEarningMetrics
+    @EvictSubscriptionMetrics
     @AuditLog(
         action = AuditLogAction.UPDATE,
         entityType = AuditLogEntityType.SUBSCRIPTION,

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
@@ -6,14 +6,12 @@ import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.SoftDeleteSubscriptionByIdUseCase;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTION;
-import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTIONS;
 
 @Service
 @RequiredArgsConstructor
@@ -22,24 +20,15 @@ public class SoftDeleteSubscriptionByIdUseCaseService implements SoftDeleteSubsc
 
    @Override
    @Transactional
-   @Caching(evict = {
-      @CacheEvict(
-         value = SUBSCRIPTIONS,
-         allEntries = true,
-         beforeInvocation = true,
-         cacheManager = "redisCacheManager"),
-      @CacheEvict(
-         value = SUBSCRIPTION,
-         key = "#id",
-         cacheManager = "redisCacheManager"
-      ),
-      @CacheEvict(
+   @CacheEvictSubscriptions
+   @Caching(
+      evict = @CacheEvict(
          value = CacheValues.PAYMENTS,
          allEntries = true,
          cacheManager = "redisCacheManager",
          beforeInvocation = true
       )
-   })
+   )
    @AuditLog(
       action = AuditLogAction.DELETE,
       entityType = AuditLogEntityType.SUBSCRIPTION,

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/UpdateSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/UpdateSubscriptionUseCaseService.java
@@ -3,6 +3,8 @@ package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictEarningMetrics;
+import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictSubscriptionMetrics;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
@@ -36,6 +38,8 @@ public class UpdateSubscriptionUseCaseService implements UpdateSubscriptionUseCa
    @Override
    @Transactional
    @CacheEvictSubscriptions
+   @EvictEarningMetrics
+   @EvictSubscriptionMetrics
    @AuditLog(
       action = AuditLogAction.UPDATE,
       entityType = AuditLogEntityType.SUBSCRIPTION,

--- a/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
@@ -181,6 +181,7 @@ public class InitConfig {
          .pricing(pricingMap.get(memberships[randomIdx]))
          .subscriptionPeriods(List.of(new PeriodEntity(periods[randomIdx], LocalDate.now())))
          .finished(random.nextBoolean())
+         .paid(true)
          .build();
    }
 

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/EarningMetricsControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/EarningMetricsControllerTest.java
@@ -6,7 +6,6 @@ import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
-import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,7 +79,7 @@ class EarningMetricsControllerTest {
    void getTotalPerMembershipType() throws Exception {
       final String URI = URI_TEMPLATE + "/memberships";
       when(service.getTotalPerMembershipType()).thenReturn(List.of(
-              new TotalPerMembershipTypeDto(Membership.MONTHLY, BigDecimal.valueOf(3_000d))
+              new TotalPerMembershipTypeDto("MONTHLY", BigDecimal.valueOf(3_000d))
       ));
 
       this.mockMvc.perform(get(URI)

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionMetricsControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionMetricsControllerTest.java
@@ -6,7 +6,6 @@ import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
-import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,7 +79,7 @@ class SubscriptionMetricsControllerTest {
    void getSubsPerMembership() throws Exception {
       final String URI = URI_TEMPLATE + "/memberships";
       when(service.getSubscriptionsPerMembership()).thenReturn(List.of(
-              new SubsPerMembership(Membership.MONTHLY, 2L)
+              new SubsPerMembership("MONTHLY", 2L)
       ));
 
       mockMvc.perform(get(URI)

--- a/src/test/java/com/jame/dev/gymApp/metrics/service/EarningMetricsServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/metrics/service/EarningMetricsServiceTest.java
@@ -4,7 +4,6 @@ import com.jame.dev.gymApp.features.metrics.domain.repository.EarningMetricsRepo
 import com.jame.dev.gymApp.features.metrics.application.service.EarningMetricsApplicationService;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth;
-import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,7 +61,7 @@ public class EarningMetricsServiceTest {
    @DisplayName("Should get total earned ")
    void getEarningsPerMembership(){
       when(repo.calculateTotalPerMembership()).thenReturn(
-              List.of(new TotalPerMembershipTypeDto(Membership.MONTHLY, BigDecimal.valueOf(9_000d)))
+              List.of(new TotalPerMembershipTypeDto("MONTHLY", BigDecimal.valueOf(9_000d)))
       );
 
       final List<TotalPerMembershipTypeDto> membershipTypeList = service.getTotalPerMembershipType();

--- a/src/test/java/com/jame/dev/gymApp/metrics/service/SubscriptionMetricsServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/metrics/service/SubscriptionMetricsServiceTest.java
@@ -5,7 +5,6 @@ import com.jame.dev.gymApp.features.metrics.domain.repository.SubscriptionMetric
 import com.jame.dev.gymApp.features.metrics.application.service.SubscriptionMetricsApplicationService;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
-import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,7 +69,7 @@ public class SubscriptionMetricsServiceTest {
    @DisplayName("Should return a list of subs by Memberships.")
    void subsByMemberships() {
       when(repo.countSubsByMembership())
-              .thenReturn(List.of(new SubsPerMembership(Membership.MONTHLY, 2L)));
+              .thenReturn(List.of(new SubsPerMembership("MONTHLY", 2L)));
 
       final List<SubsPerMembership> membershipCountList = service.getSubscriptionsPerMembership();
 


### PR DESCRIPTION
# Description

This PR improves the metrics caching strategy by introducing cache-friendly response record classes compatible with `RedisCacheManager` and integrating cache eviction throughout the subscription lifecycle. It also standardizes metrics responses, applies caching to expensive read operations, and ensures cached data remains synchronized after subscription mutations.

# Main Changes

- Introduced dedicated response record classes (`TotalEarned`, `TotalSubscriptions`, and `TotalPerMonthResponse`) to improve serialization and compatibility with `RedisCacheManager`.
- Refactored metrics controllers and service contracts to return strongly typed response objects instead of generic `Map` responses.
- Added `@Cacheable` annotations across earnings and subscription metrics services to cache frequently requested metrics.
- Created centralized cache key definitions (`CacheEarningMetricValues` and `CacheSubsMetricsValues`) to avoid duplicated cache names and improve maintainability.
- Implemented custom cache eviction annotations (`@EvictEarningMetrics` and `@EvictSubscriptionMetrics`) to encapsulate eviction logic and reduce annotation duplication.
- Integrated metrics cache eviction into subscription mutation flows (create, update, renew, and related operations) to ensure cached metrics remain consistent after data changes.
- Updated repository queries to return cacheable response records and adapted metrics queries to operate over paid subscriptions.
- Refactored monthly earnings responses into structured collections grouped by year for a more consistent API contract.

# Minimal Changes

- Removed temporary `Map`-based response builders from metrics controllers.
- Replaced `Membership` enum references with `String` values in metrics DTOs to simplify serialization.
- Eliminated duplicated helper methods that returned empty collections.
- Centralized cache name constants into dedicated classes.
- Updated unit and controller tests to reflect the new response types.
- Adjusted seed data initialization to generate paid subscriptions for metrics consistency.

# Notes

- The new response records provide better compatibility with Redis serialization while keeping API contracts strongly typed.
- Centralized cache eviction annotations simplify future maintenance and reduce the risk of forgetting to invalidate related metrics.
- Additional metrics endpoints can adopt the same cache pattern with minimal implementation effort.