### PR TITLE
More Metrics Cases.

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/EarningMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/EarningMetricsController.java
@@ -1,5 +1,6 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningByYearResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
@@ -31,5 +32,10 @@ public class EarningMetricsController {
    @GetMapping("/memberships")
    public ResponseEntity<List<TotalPerMembershipTypeDto>> getTotalPerMembershipType() {
       return ResponseEntity.ok(service.getTotalPerMembershipType());
+   }
+
+   @GetMapping("/rankings/periods")
+   public ResponseEntity<List<PeriodicalEarningByYearResponse>> getPeriodicalEarningsByYearRanking() {
+      return ResponseEntity.ok(service.getPeriodicalEarnings());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
@@ -1,5 +1,7 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
+import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingPerYear;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
@@ -22,12 +24,22 @@ public class SubscriptionMetricsController {
    private final SubscriptionMetricsService service;
 
    @GetMapping("/totals")
-   public ResponseEntity<TotalSubscriptions> getTotalSubscriptions(){
-      return  ResponseEntity.ok(service.getTotalSubscriptions());
+   public ResponseEntity<TotalSubscriptions> getTotalSubscriptions() {
+      return ResponseEntity.ok(service.getTotalSubscriptions());
+   }
+
+   @GetMapping("/rankings/memberships")
+   public ResponseEntity<List<MembershipRanking>> getMembershipRankings() {
+      return ResponseEntity.ok(service.getMembershipRanking());
+   }
+
+   @GetMapping("/rankings/periods")
+   public ResponseEntity<List<PeriodRankingPerYear>> getPeriodRankings() {
+      return ResponseEntity.ok(service.getPeriodRanking());
    }
 
    @GetMapping("/{date}/before")
-   public ResponseEntity<TotalSubscriptions> getTotalBefore(@PathVariable("date") final LocalDate date){
+   public ResponseEntity<TotalSubscriptions> getTotalBefore(@PathVariable("date") final LocalDate date) {
       return ResponseEntity.ok(service.getSubscriptionsBefore(date));
    }
 

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/MembershipRanking.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/MembershipRanking.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MembershipRanking(
+   @JsonProperty("membership") String membership,
+   @JsonProperty("subsCount") long subsCount,
+   @JsonProperty("rank") long rank
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodRankingPerYear.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodRankingPerYear.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.PeriodRanking;
+
+import java.util.List;
+
+public record PeriodRankingPerYear(
+   @JsonProperty("year") int year,
+   @JsonProperty("totalPerYear") List<PeriodRanking> totalPerYear
+   ) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodicalEarningByYearResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodicalEarningByYearResponse.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.PeriodicalEarning;
+
+import java.util.List;
+
+public record PeriodicalEarningByYearResponse(
+   @JsonProperty("year") Integer year,
+   @JsonProperty("periodicalEarnings") List<PeriodicalEarning> periodicalEarnings
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EarningMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EarningMetricsService.java
@@ -1,5 +1,6 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningByYearResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
@@ -12,4 +13,6 @@ public interface EarningMetricsService {
    List<TotalPerMonthResponse> getTotalPerMonth();
 
    List<TotalPerMembershipTypeDto> getTotalPerMembershipType();
+
+   List<PeriodicalEarningByYearResponse> getPeriodicalEarnings();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
@@ -1,5 +1,7 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
+import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingPerYear;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
@@ -10,6 +12,10 @@ import java.util.List;
 
 public interface SubscriptionMetricsService {
    TotalSubscriptions getTotalSubscriptions();
+
+   List<MembershipRanking> getMembershipRanking();
+
+   List<PeriodRankingPerYear> getPeriodRanking();
 
    TotalSubscriptions getSubscriptionsBefore(@NonNull final LocalDate date);
 

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
@@ -1,11 +1,10 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningByYearResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
-import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
-import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth;
+import com.jame.dev.gymApp.features.metrics.domain.model.*;
 import com.jame.dev.gymApp.features.metrics.domain.repository.EarningMetricsRepository;
 import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEarningMetricValues;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +23,8 @@ public class EarningMetricsApplicationService implements EarningMetricsService {
 
    @Override
    @Cacheable(
-      value = CacheEarningMetricValues.EARNING_TOTAL
+      value = CacheEarningMetricValues.EARNING_TOTAL,
+      unless = "#result == null"
    )
    public TotalEarned getTotal() {
       return repo.calculateTotalEarned();
@@ -62,4 +62,30 @@ public class EarningMetricsApplicationService implements EarningMetricsService {
       return dtoList.isEmpty() ? List.of() : dtoList;
    }
 
+   @Override
+   @Cacheable(
+      value = CacheEarningMetricValues.EARNING_PERIODICAL,
+      unless = "#result == null || #result.isEmpty()"
+   )
+   public List<PeriodicalEarningByYearResponse> getPeriodicalEarnings() {
+      return repo.calculatePeriodicalEarnings()
+         .stream()
+         .collect(
+            Collectors.groupingBy(
+               YearPeriodicalEarning::year,
+               Collectors.mapping(
+                  data -> PeriodicalEarning.builder()
+                     .totalEarned(data.totalEarned())
+                     .membership(data.membership())
+                     .period(data.period())
+                     .rank(data.rank())
+                     .build(),
+                  Collectors.toUnmodifiableList()
+               )
+            ))
+         .entrySet()
+         .stream()
+         .map(data -> new PeriodicalEarningByYearResponse(data.getKey(), data.getValue()))
+         .toList();
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
@@ -1,7 +1,11 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
+import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingPerYear;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
+import com.jame.dev.gymApp.features.metrics.domain.model.PeriodRanking;
+import com.jame.dev.gymApp.features.metrics.domain.model.PeriodSubscribersRanking;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import com.jame.dev.gymApp.features.metrics.domain.repository.SubscriptionMetricsRepository;
@@ -14,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +28,8 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
 
    @Override
    @Cacheable(
-      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL, unless = "#result == null"
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL,
+      unless = "#result == null"
    )
    public TotalSubscriptions getTotalSubscriptions() {
       return repo.countAllSubscriptionDistinct();
@@ -31,7 +37,42 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
 
    @Override
    @Cacheable(
-      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_BEFORE, unless = "#result == null"
+      value = CacheSubsMetricsValues.SUBSCRIPTION_RANKING,
+      unless = "#result == null || #result.isEmpty()"
+   )
+   public List<MembershipRanking> getMembershipRanking() {
+      return repo.calculateMembershipRanking();
+   }
+
+   @Override
+   @Cacheable(
+      value = CacheSubsMetricsValues.SUBSCRIPTION_PERIOD_RANKING,
+      unless = "#result == null || #result.isEmpty()"
+   )
+   public List<PeriodRankingPerYear> getPeriodRanking() {
+      return repo.calculatePeriodWithMostSubscribers()
+         .stream()
+         .collect(
+            Collectors.groupingBy(
+               PeriodSubscribersRanking::year,
+               Collectors.mapping(dto ->
+                     PeriodRanking.builder()
+                        .period(dto.period())
+                        .subscriptionType(dto.subscriptionType())
+                        .subscriptionCount(dto.subscriptionCount())
+                        .rank(dto.rank())
+                        .build(),
+                  Collectors.toUnmodifiableList())))
+         .entrySet()
+         .stream()
+         .map((map) -> new PeriodRankingPerYear(map.getKey(), map.getValue()))
+         .toList();
+   }
+
+   @Override
+   @Cacheable(
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_BEFORE,
+      unless = "#result == null"
    )
    public TotalSubscriptions getSubscriptionsBefore(@NonNull LocalDate date) {
       return repo.countByStartDateBefore(date);
@@ -39,7 +80,8 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
 
    @Override
    @Cacheable(
-      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH, unless = "#result == null || #result.isEmpty()"
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH,
+      unless = "#result == null || #result.isEmpty()"
    )
    public List<SubsPerMonthDto> getSubscriptionsPerMonth() {
       return repo.countSubsByMonth();
@@ -47,7 +89,8 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
 
    @Override
    @Cacheable(
-      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MEMBERSHIP, unless = "#result == null || #result.isEmpty()"
+      value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MEMBERSHIP,
+      unless = "#result == null || #result.isEmpty()"
    )
    public List<SubsPerMembership> getSubscriptionsPerMembership() {
       return repo.countSubsByMembership();

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/PeriodRanking.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/PeriodRanking.java
@@ -1,0 +1,13 @@
+package com.jame.dev.gymApp.features.metrics.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record PeriodRanking(
+   @JsonProperty("period") String period,
+   @JsonProperty("subscriptionType") String subscriptionType,
+   @JsonProperty("subscriptionCount") long subscriptionCount,
+   @JsonProperty("rank") long rank
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/PeriodSubscribersRanking.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/PeriodSubscribersRanking.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.domain.model;
+
+public record PeriodSubscribersRanking(
+   int year,
+   String period,
+   String subscriptionType,
+   long subscriptionCount,
+   long rank
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/PeriodicalEarning.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/PeriodicalEarning.java
@@ -1,0 +1,15 @@
+package com.jame.dev.gymApp.features.metrics.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+public record PeriodicalEarning(
+   @JsonProperty("totalEarned") BigDecimal totalEarned,
+   @JsonProperty("membership") String membership,
+   @JsonProperty("period") String period,
+   @JsonProperty("rank") long rank
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/YearPeriodicalEarning.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/YearPeriodicalEarning.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.features.metrics.domain.model;
+
+import java.math.BigDecimal;
+
+public record YearPeriodicalEarning(
+   int year,
+   String period,
+   String membership,
+   BigDecimal totalEarned,
+   long rank
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EarningMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EarningMetricsRepository.java
@@ -3,6 +3,7 @@ package com.jame.dev.gymApp.features.metrics.domain.repository;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth;
+import com.jame.dev.gymApp.features.metrics.domain.model.YearPeriodicalEarning;
 import com.jame.dev.gymApp.features.metrics.infrastructure.query.MetricsRepository;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
 import org.springframework.data.jpa.repository.NativeQuery;
@@ -13,7 +14,7 @@ public interface EarningMetricsRepository extends MetricsRepository<Subscription
 
    @NativeQuery("""
            SELECT
-             COALESCE(SUM(mp.price), 0) as total
+              DISTINCT COALESCE(SUM(mp.price), 0) as total
            FROM subscriptions s
            INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
            WHERE s.paid = true
@@ -52,4 +53,23 @@ public interface EarningMetricsRepository extends MetricsRepository<Subscription
            ORDER BY m.membership DESC
            """)
    List<TotalPerMembershipTypeDto> calculateTotalPerMembership();
+
+   @NativeQuery("""
+      SELECT
+        CAST(EXTRACT(YEAR FROM p.start_period) AS INTEGER) AS year,
+        CAST(
+           UPPER(
+             CONCAT(TO_CHAR(p.start_period, 'FMMon'), ' - ', TO_CHAR(p.end_period, 'FMMon'))) AS varchar(12)
+           ) AS period,
+        CAST(p.period AS varchar(12)) AS membership,
+        COALESCE(SUM(mp.price), 0) AS totalEarned,
+        RANK() OVER (ORDER BY COALESCE(SUM(mp.price), 0) DESC, EXTRACT(YEAR FROM p.start_period) DESC) AS rank
+      FROM subscriptions s
+      INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
+      INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
+      INNER JOIN periods p ON p.id = sp.period_id
+      WHERE s.paid = true
+      GROUP BY p.start_period, p.end_period, p.period
+      """)
+   List<YearPeriodicalEarning> calculatePeriodicalEarnings();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
@@ -1,5 +1,7 @@
 package com.jame.dev.gymApp.features.metrics.domain.repository;
 
+import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
+import com.jame.dev.gymApp.features.metrics.domain.model.PeriodSubscribersRanking;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
@@ -14,8 +16,44 @@ import java.util.List;
 public interface SubscriptionMetricsRepository extends
    MetricsRepository<SubscriptionEntity, Long> {
 
-   @NativeQuery("SELECT DISTINCT COUNT(*) AS total FROM subscriptions WHERE paid = true")
+   @NativeQuery("SELECT DISTINCT COUNT(s) AS total FROM subscriptions s WHERE paid = true")
    TotalSubscriptions countAllSubscriptionDistinct();
+
+   @NativeQuery(
+      """
+      SELECT
+          m.membership AS membership,
+          COUNT(m.membership) AS subsCount,
+          RANK() OVER (ORDER BY COUNT(*) DESC, COALESCE(SUM(mp.price), 0) DESC) AS rank
+      FROM subscriptions s
+      INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
+      INNER JOIN memberships m ON m.id = mp.membership_id
+      WHERE s.paid = true
+      GROUP BY m.membership
+      """)
+   List<MembershipRanking> calculateMembershipRanking();
+
+   @NativeQuery("""
+      SELECT
+         CAST(EXTRACT(YEAR FROM p.start_period) AS INTEGER) AS year,
+         CAST(UPPER(CONCAT(
+            TO_CHAR(
+               p.start_period, 'FMMon'),
+               ' - ',
+               TO_CHAR(p.end_period, 'FMMon')
+               )) AS VARCHAR(10)) AS period,
+         CAST(p.period AS varchar(10)) AS subscriptionType,
+         COUNT(s) AS subscriptionCount,
+         RANK() OVER (ORDER BY COUNT(s) DESC, COALESCE(SUM(mp.price), 0) DESC, EXTRACT(YEAR FROM p.start_period) DESC) AS rank
+      FROM subscriptions s
+      INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
+      INNER JOIN memberships m ON m.id = mp.membership_id
+      INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
+      INNER JOIN periods p ON p.id = sp.period_id
+      WHERE s.paid = true
+      GROUP BY p.start_period, p.end_period, p.period
+      """)
+   List<PeriodSubscribersRanking> calculatePeriodWithMostSubscribers();
 
    @NativeQuery("""
       SELECT

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictEarningMetrics.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictEarningMetrics.java
@@ -14,7 +14,8 @@ import java.lang.annotation.*;
 @Caching(evict = {
    @CacheEvict(value = CacheEarningMetricValues.EARNING_TOTAL, allEntries = true, cacheManager = "redisCacheManager"),
    @CacheEvict(value = CacheEarningMetricValues.EARNING_PER_MONTH, allEntries = true, cacheManager = "redisCacheManager"),
-   @CacheEvict(value = CacheEarningMetricValues.EARNING_MEMBERSHIP_TYPE, allEntries = true, cacheManager = "redisCacheManager")
+   @CacheEvict(value = CacheEarningMetricValues.EARNING_MEMBERSHIP_TYPE, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheEarningMetricValues.EARNING_PERIODICAL, allEntries = true, cacheManager = "redisCacheManager"),
 })
 public @interface EvictEarningMetrics {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictSubscriptionMetrics.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictSubscriptionMetrics.java
@@ -14,7 +14,9 @@ import java.lang.annotation.*;
    @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL, allEntries = true, cacheManager = "redisCacheManager"),
    @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_BEFORE, allEntries = true, cacheManager = "redisCacheManager"),
    @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MEMBERSHIP, allEntries = true, cacheManager = "redisCacheManager"),
-   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH, allEntries = true, cacheManager = "redisCacheManager")
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_RANKING, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_PERIOD_RANKING, allEntries = true, cacheManager = "redisCacheManager"),
 })
 public @interface EvictSubscriptionMetrics {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheEarningMetricValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheEarningMetricValues.java
@@ -4,4 +4,5 @@ public class CacheEarningMetricValues {
    public final static String EARNING_TOTAL = "earnings:total";
    public final static String EARNING_PER_MONTH = "earnings:per:month";
    public final static String EARNING_MEMBERSHIP_TYPE = "earnings:membership";
+   public final static String EARNING_PERIODICAL = "earnings:periodical";
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheSubsMetricsValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheSubsMetricsValues.java
@@ -5,4 +5,6 @@ public class CacheSubsMetricsValues {
    public static final String SUBSCRIPTION_TOTAL_BEFORE = "subscriptions:metrics:total:before";
    public static final String SUBSCRIPTION_TOTAL_PER_MONTH = "subscriptions:metrics:total:month";
    public static final String SUBSCRIPTION_TOTAL_PER_MEMBERSHIP = "subscriptions:metrics:total:memberships";
+   public static final String SUBSCRIPTION_RANKING = "subscriptions:metrics:membership:ranking";
+   public static final String SUBSCRIPTION_PERIOD_RANKING = "subscriptions:metrics:period:ranking";
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/UpdateSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/UpdateSubscriptionUseCaseService.java
@@ -55,13 +55,12 @@ public class UpdateSubscriptionUseCaseService implements UpdateSubscriptionUseCa
          .orElseThrow(() -> new PricingNotFoundException("Pricing Not Found."));
 
       subscriptionUpdater.apply(subscriptionEntity, pricingEntity);
-      final SubscriptionEntity subscriptionModified = subscriptionMutationRepository.save(subscriptionEntity);
 
-      Optional.ofNullable(subscriptionModified.getPayments())
+      Optional.ofNullable(subscriptionEntity.getPayments())
          .filter(Predicate.not(List::isEmpty))
          .map(List::getLast)
          .ifPresent(s -> s.setAmount(pricingEntity.getPrice()));
 
-      return subscriptionFactory.createFromEntity(subscriptionModified);
+      return subscriptionFactory.createFromEntity(subscriptionMutationRepository.save(subscriptionEntity));
    }
 }


### PR DESCRIPTION
# Description

This PR extends the Metrics module by introducing new ranking-focused endpoints for both **Subscription Metrics** and **Earning Metrics**. It provides aggregated rankings by membership and period, grouping period-based results by year to simplify frontend consumption. The implementation also expands the caching strategy and introduces the necessary domain models and response DTOs to support the new analytical use cases.

# Main Changes

- Added new Subscription Metrics endpoints:
  - `GET /metrics/subs/rankings/memberships`
  - `GET /metrics/subs/rankings/periods`
- Added new Earning Metrics endpoint:
  - `GET /metrics/earnings/rankings/periods`
- Implemented membership ranking retrieval based on subscription count.
- Implemented period-based subscription rankings grouped by year.
- Implemented period-based earnings rankings grouped by year.
- Added new service contract methods and corresponding application service implementations for all ranking use cases.
- Introduced new repository queries using SQL window functions (`RANK()`) to calculate rankings directly in the database.
- Added response DTOs for:
  - Membership rankings.
  - Subscription period rankings grouped by year.
  - Periodical earnings grouped by year.
- Added new domain models representing ranking data and yearly grouped results.
- Extended Redis caching with dedicated cache regions for the new ranking metrics.
- Updated cache eviction annotations to invalidate the newly introduced ranking caches whenever subscription or earning data changes.

# Minimal Changes

- Improved formatting and consistency across controllers and service implementations.
- Added `unless` conditions to cache annotations to avoid caching null or empty results.
- Corrected the total subscription query to use `COUNT(s)` for improved consistency.
- Updated the total earnings query with `DISTINCT` aggregation.
- Refactored imports using wildcard imports where appropriate.
- Simplified the subscription update flow by persisting the entity after payment amount synchronization.

# Notes

- Ranking calculations rely on SQL window functions, making the database responsible for ordering and ranking results efficiently.
- Period-based rankings are grouped by year in the service layer, reducing transformation work for frontend consumers.
- The newly introduced cache entries should be monitored to ensure proper invalidation whenever subscription or payment data changes.
- The current ranking infrastructure provides a reusable foundation for future analytical endpoints, such as top-performing periods by revenue, membership growth trends, or customizable ranking filters.