### PR TITLE
Payment administration metrics

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentAdminMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentAdminMetricsController.java
@@ -1,0 +1,32 @@
+package com.jame.dev.gymApp.features.metrics.api;
+
+import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsAdminService;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/app/v1/administration/metrics/payments")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class PaymentAdminMetricsController {
+
+   private final PaymentMetricsAdminService paymentMetricsAdminService;
+
+   @GetMapping("/resume")
+   public ResponseEntity<AnnualResumeResponse> getAnnualResume() {
+      return ResponseEntity.ok(paymentMetricsAdminService.getAnnualResume());
+   }
+
+   @GetMapping("/evolution")
+   public ResponseEntity<List<MonthTotal>> getMonthInvestmentEvolution() {
+      return ResponseEntity.ok(paymentMetricsAdminService.getInvestmentMonthEvolution());
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentSubscriberMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentSubscriberMetricsController.java
@@ -2,7 +2,7 @@ package com.jame.dev.gymApp.features.metrics.api;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
-import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsService;
+import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsSubscriberService;
 import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +20,7 @@ import java.util.List;
 @PreAuthorize("hasRole('USER')")
 public class PaymentSubscriberMetricsController {
 
-   private final PaymentMetricsService paymentMetricsService;
+   private final PaymentMetricsSubscriberService paymentMetricsService;
 
    @PreAuthorize("@customerSecurity.isOwner(#customerId, authentication)")
    @GetMapping("/{customerId}/investments")

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsAdminService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsAdminService.java
@@ -1,0 +1,13 @@
+package com.jame.dev.gymApp.features.metrics.application.contract;
+
+import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+
+import java.util.List;
+
+public interface PaymentMetricsAdminService {
+
+   AnnualResumeResponse getAnnualResume();
+
+   List<MonthTotal> getInvestmentMonthEvolution();
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsSubscriberService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsSubscriberService.java
@@ -6,7 +6,7 @@ import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 
 import java.util.List;
 
-public interface PaymentMetricsService {
+public interface PaymentMetricsSubscriberService {
 
    TotalInvestment getTotalExpend(final long customerId);
    AnnualResumeResponse getAnnualResume(final long customerId);

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsAdminApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsAdminApplicationService.java
@@ -1,0 +1,36 @@
+package com.jame.dev.gymApp.features.metrics.application.service;
+
+import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsAdminService;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+import com.jame.dev.gymApp.features.metrics.domain.repository.PaymentMetricsRepository;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CachePaymentMetricsValues;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentMetricsAdminApplicationService implements PaymentMetricsAdminService {
+   private final PaymentMetricsRepository paymentMetricsRepository;
+
+   @Override
+   @Cacheable(
+      value = CachePaymentMetricsValues.RESUME,
+      unless = "#result == null"
+   )
+   public AnnualResumeResponse getAnnualResume() {
+      return paymentMetricsRepository.calculateAnnualResume();
+   }
+
+   @Override
+   @Cacheable(
+      value = CachePaymentMetricsValues.EVOLUTION,
+      unless = "#result == null || #result.isEmpty()"
+   )
+   public List<MonthTotal> getInvestmentMonthEvolution() {
+      return paymentMetricsRepository.calculatePaymentEvolutionAlongMonths();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsSubscriberApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsSubscriberApplicationService.java
@@ -2,7 +2,7 @@ package com.jame.dev.gymApp.features.metrics.application.service;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
-import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsService;
+import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsSubscriberService;
 import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import com.jame.dev.gymApp.features.metrics.domain.repository.PaymentMetricsRepository;
 import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CachePaymentMetricsValues;
@@ -17,7 +17,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class PaymentMetricsSubscriberService implements PaymentMetricsService {
+public class PaymentMetricsSubscriberApplicationService implements PaymentMetricsSubscriberService {
    private final PaymentMetricsRepository paymentMetricsRepository;
 
    @Override

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/PaymentMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/PaymentMetricsRepository.java
@@ -20,7 +20,6 @@ public interface PaymentMetricsRepository extends MetricsRepository<PaymentEntit
       """)
    TotalInvestment calculateTotalAmountExpended(@Param("customerId") long customerId);
 
-
    @NativeQuery("""
       SELECT
           COUNT(*) AS totalPaymentsMade,
@@ -38,6 +37,20 @@ public interface PaymentMetricsRepository extends MetricsRepository<PaymentEntit
 
    @NativeQuery("""
       SELECT
+          COUNT(*) AS totalPaymentsMade,
+          COALESCE(SUM(p.amount), 0) AS totalExpend,
+          COALESCE(ROUND(AVG(p.amount), 2), 0) AS avergare,
+          COUNT(*) FILTER ( WHERE p.payment_method = 'ELECTRONIC' ) as electronicPaymentsDone,
+          COUNT(*) FILTER ( WHERE p.payment_method = 'PHYSIC' ) as physicPaymentsDone
+      FROM payments p
+      WHERE
+          p.created_at >= DATE_TRUNC('year', CURRENT_DATE) AND
+          p.created_at < date_trunc('year', CURRENT_DATE) + INTERVAL '1 year'
+      """)
+   AnnualResumeResponse calculateAnnualResume();
+
+   @NativeQuery("""
+      SELECT
           TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
           COALESCE(SUM(p.amount), 0) AS total
       FROM generate_series(1, 12) AS m(month_number)
@@ -51,4 +64,19 @@ public interface PaymentMetricsRepository extends MetricsRepository<PaymentEntit
       ORDER BY m.month_number
       """)
    List<MonthTotal> calculatePaymentEvolutionAlongMonths(@Param("customerId") long customerId);
+
+   @NativeQuery("""
+      SELECT
+          TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
+          COALESCE(SUM(p.amount), 0) AS total
+      FROM generate_series(1, 12) AS m(month_number)
+      LEFT JOIN payments p
+          ON EXTRACT(MONTH FROM p.created_at) = m.month_number
+          AND p.amount > 0
+          AND p.created_at >= DATE_TRUNC('year', CURRENT_DATE)
+          AND p.created_at < DATE_TRUNC('year', CURRENT_DATE) + INTERVAL '1 year'
+      GROUP BY m.month_number
+      ORDER BY m.month_number
+      """)
+   List<MonthTotal> calculatePaymentEvolutionAlongMonths();
 }

--- a/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
@@ -5,9 +5,10 @@ import com.jame.dev.gymApp.features.auth.application.contract.verification.Verif
 import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
 import com.jame.dev.gymApp.features.customer.infrastructure.persistence.CustomerRepository;
-import com.jame.dev.gymApp.features.subscription.application.contract.MembershipService;
-import com.jame.dev.gymApp.features.subscription.application.contract.PricingService;
 import com.jame.dev.gymApp.features.subscription.domain.model.*;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.MembershipRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PaymentRepository;
+import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
 import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
 import com.jame.dev.gymApp.features.user.application.contract.UserFactory;
@@ -51,7 +52,6 @@ public class InitConfig {
    private String passwordUser;
 
    private final Random random = new Random();
-   private final List<String> ORDER = List.of("biweekly", "monthly", "quarterly", "annual");
    private final Map<String, BigDecimal> prices = Map.ofEntries(
       Map.entry("biweekly", BigDecimal.valueOf(150.00d)),
       Map.entry("monthly", BigDecimal.valueOf(300.00d)),
@@ -73,11 +73,12 @@ public class InitConfig {
 
    @Bean
    @Priority(1)
-   public CommandLineRunner runnerInitUsersAndCustomers(final UserRepository userRepository,
-                                                        final UserFactory userFactory,
-                                                        final CustomerRepository customerRepository,
-                                                        final TokenGeneratorService tokenService,
-                                                        final VerificationService verificationService) {
+   public CommandLineRunner runnerInitUsersAndCustomers(
+      final UserRepository userRepository,
+      final UserFactory userFactory,
+      final CustomerRepository customerRepository,
+      final TokenGeneratorService tokenService,
+      final VerificationService verificationService) {
       return args -> {
          final var admin = UserRequest.builder()
             .name("admin")
@@ -108,23 +109,18 @@ public class InitConfig {
 
    @Bean
    @Priority(2)
-   public CommandLineRunner runnerMembershipsAndPrices(final MembershipService membershipService, final PricingService pricingService) {
+   public CommandLineRunner runnerMembershipsAndPrices(
+      final MembershipRepository membershipRepository,
+      final PricingRepository pricingRepository) {
       return args -> {
 
-         final Map<String, MemberShipEntity> memberships = new LinkedHashMap<>();
-         ORDER.forEach(name -> {
-            final Membership type = Membership.valueOf(name.toUpperCase());
-            final MemberShipEntity entity = membershipService.save(new MemberShipEntity(null, type));
-            memberships.put(name, entity);
+         prices.forEach((membership, price) -> {
+            final Membership type = Membership.valueOf(membership.toUpperCase());
+            final MemberShipEntity memberShipEntity = membershipRepository.saveAndFlush(new MemberShipEntity(null, type));
+            final PricingEntity pricingEntity = pricingRepository.saveAndFlush(new PricingEntity(null, memberShipEntity, price));
+            pricingMap.putIfAbsent(type, pricingEntity);
          });
 
-         ORDER.forEach(name -> {
-            final MemberShipEntity membership = memberships.get(name);
-            final BigDecimal price = prices.get(name);
-
-            final var pricingEntity = pricingService.save(new PricingEntity(null, membership, price));
-            pricingMap.putIfAbsent(pricingEntity.getMemberShipEntity().getMembership(), pricingEntity);
-         });
          log.info("Runner MembershipAndPrices end execution.");
       };
    }
@@ -137,7 +133,8 @@ public class InitConfig {
       final TokenGeneratorService tokenGeneratorService,
       final VerificationService verificationService,
       final CustomerRepository customerRepository,
-      final SubscriptionRepository subscriptionRepository
+      final SubscriptionRepository subscriptionRepository,
+      final PaymentRepository paymentRepository
    ) {
       return args -> {
          log.info("Runner CreationOfUsersCustomersAndSubscriptions start execution.");
@@ -153,6 +150,8 @@ public class InitConfig {
                //Subscriptions
                final var subscription = createSubscription(customerEntity);
                subscriptionRepository.save(subscription);
+
+               paymentRepository.saveAndFlush(createPaymentEntity(subscription));
             });
          log.info("Runner CreationOfUsersCustomersAndSubscriptions end execution.");
       };
@@ -182,6 +181,20 @@ public class InitConfig {
          .subscriptionPeriods(List.of(new PeriodEntity(periods[randomIdx], LocalDate.now())))
          .finished(random.nextBoolean())
          .paid(true)
+         .build();
+   }
+
+   private PaymentEntity createPaymentEntity(final SubscriptionEntity subscriptionEntity) {
+      return PaymentEntity.builder()
+         .stripeSessionId(UUID.randomUUID().toString())
+         .stripePaymentIntentId(PaymentPhysicMeta.PAYMENT_INTEND_ID.getValue())
+         .stripeSubscriptionId(PaymentPhysicMeta.STRIPE_SUBSCRIPTION_ID.getValue())
+         .amount(subscriptionEntity.getPricing().getPrice())
+         .currency("mx")
+         .status(PaymentStatus.COMPLETED)
+         .paymentMethod(PaymentMethod.PHYSIC)
+         .subscription(subscriptionEntity)
+         .customer(subscriptionEntity.getCustomer())
          .build();
    }
 


### PR DESCRIPTION
# Description

This PR introduces administrative payment metrics endpoints through the new `PaymentAdminMetricsController`, allowing administrators to retrieve both the annual payment summary and the monthly payment evolution. The implementation separates subscriber and administration responsibilities, providing a cleaner service architecture while exposing aggregated payment metrics for the administration dashboard.

# Main Changes

- Implemented `PaymentAdminMetricsController` with endpoints to retrieve:
  - Annual payment resume.
  - Monthly payment evolution.
- Added the `PaymentMetricsAdminService` contract and its corresponding `PaymentMetricsAdminApplicationService` implementation.
- Implemented caching for administrative payment metrics, including both annual resume and monthly evolution responses.
- Extended `PaymentMetricsRepository` with new administrative queries to retrieve:
  - Global annual payment statistics.
  - Overall monthly payment evolution for the current year.
- Refactored payment metrics services by separating subscriber-specific functionality from administration functionality.
- Renamed the subscriber payment service contract and implementation to clearly distinguish them from the new administrative services.
- Updated `PaymentSubscriberMetricsController` to consume the renamed subscriber service.
- Enhanced application initialization to generate payment records alongside seeded subscriptions, enabling meaningful payment metrics during development.

# Minimal Changes

- Renamed `PaymentMetricsService` to `PaymentMetricsSubscriberService` for clearer responsibility separation.
- Renamed the subscriber application service implementation to match the updated contract naming.
- Removed obsolete membership ordering logic from the initialization configuration.
- Refactored seed initialization to use repositories directly when creating memberships, pricing, and payment data.
- Applied minor formatting and dependency cleanup within the initialization configuration.

# Notes

- The administrative payment metrics are independent from subscriber-specific metrics, making future maintenance and feature expansion easier.
- The service split establishes a clearer separation of concerns and allows administrative reporting to evolve without affecting customer-facing endpoints.
- Additional administrative payment analytics (custom date ranges, payment method breakdowns, revenue trends, or comparative reports) can be incorporated into the new service layer with minimal impact on existing subscriber functionality.