### PR TITLE
Evolution Metrics

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/domain/model/BaseEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/domain/model/BaseEntity.java
@@ -54,4 +54,9 @@ public abstract class BaseEntity {
    public void setCreatedAt() {
       this.createdAt = Instant.now();
    }
+
+   @PreRemove
+   public void setDeletedAt() {
+      this.deletedAt = Instant.now();
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/customer/application/service/mutation/CreateCustomerUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/customer/application/service/mutation/CreateCustomerUseCaseService.java
@@ -11,9 +11,11 @@ import com.jame.dev.gymApp.features.customer.application.support.validator.Custo
 import com.jame.dev.gymApp.features.customer.application.usecases.mutation.CreateCustomerUseCase;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
 import com.jame.dev.gymApp.features.customer.domain.repository.CustomerMutationRepository;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,25 +24,30 @@ import static com.jame.dev.gymApp.application.model.CacheValues.CUSTOMERS;
 @Service
 @RequiredArgsConstructor
 public class CreateCustomerUseCaseService implements CreateCustomerUseCase {
-    private final CustomerMutationRepository customerMutationRepository;
-    private final CustomerValidator customerValidator;
-    private final CustomerFactory customerFactory;
+   private final CustomerMutationRepository customerMutationRepository;
+   private final CustomerValidator customerValidator;
+   private final CustomerFactory customerFactory;
 
-    @Override
-    @Transactional
-    @CacheEvict(value = CUSTOMERS, allEntries = true)
-    @AuditLog(
-        action = AuditLogAction.INSERT,
-        entityType = AuditLogEntityType.CUSTOMER,
-        entityId = "#result.id",
-        input = "#request",
-        result = "#result"
-    )
-    public CustomerResponse create(CustomerRequest request) {
-        final UserEntity user = customerValidator.validateUserBeforeCreation(request);
-        final CustomerEntity customerEntity = customerFactory
-            .createFromInput(new CustomerFactoryDtoInput(user, request));
-        final CustomerEntity customerSaved = customerMutationRepository.save(customerEntity);
-        return customerFactory.createFromEntity(customerSaved);
-    }
+   @Override
+   @Transactional
+   @Caching(
+      evict = {
+         @CacheEvict(value = CUSTOMERS, allEntries = true, cacheManager = "redisCacheManager"),
+         @CacheEvict(value = CacheEvolutionMetricsValues.JOINING_CUSTOMERS, allEntries = true, cacheManager = "redisCacheManager")
+      }
+   )
+   @AuditLog(
+      action = AuditLogAction.INSERT,
+      entityType = AuditLogEntityType.CUSTOMER,
+      entityId = "#result.id",
+      input = "#request",
+      result = "#result"
+   )
+   public CustomerResponse create(CustomerRequest request) {
+      final UserEntity user = customerValidator.validateUserBeforeCreation(request);
+      final CustomerEntity customerEntity = customerFactory
+         .createFromInput(new CustomerFactoryDtoInput(user, request));
+      final CustomerEntity customerSaved = customerMutationRepository.save(customerEntity);
+      return customerFactory.createFromEntity(customerSaved);
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/customer/infrastructure/annotations/CacheEvictCustomers.java
+++ b/src/main/java/com/jame/dev/gymApp/features/customer/infrastructure/annotations/CacheEvictCustomers.java
@@ -1,5 +1,6 @@
 package com.jame.dev.gymApp.features.customer.infrastructure.annotations;
 
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Caching;
 
@@ -24,6 +25,11 @@ import static com.jame.dev.gymApp.application.model.CacheValues.*;
    @CacheEvict(
       value = CUSTOMER,
       key = "#id",
+      cacheManager = "redisCacheManager"
+   ),
+   @CacheEvict(
+      value = CacheEvolutionMetricsValues.DOWNING_CUSTOMERS,
+      allEntries = true,
       cacheManager = "redisCacheManager"
    )
 })

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/EvolutionMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/EvolutionMetricsController.java
@@ -1,0 +1,48 @@
+package com.jame.dev.gymApp.features.metrics.api;
+
+
+import com.jame.dev.gymApp.features.metrics.api.response.BillingEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.CustomerEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriberEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.application.contract.EvolutionMetricsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/app/v1/administration/metrics/evolutions")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class EvolutionMetricsController {
+
+   private final EvolutionMetricsService evolutionMetricsService;
+
+   @GetMapping("/{year}/billings")
+   public ResponseEntity<BillingEvolutionResponse> getBillingEvolution(final @PathVariable int year) {
+      return ResponseEntity.ok(evolutionMetricsService.getBillingEvolution(year));
+   }
+
+   @GetMapping("/{year}/customers/downs")
+   public ResponseEntity<CustomerEvolutionResponse> getDowningCustomersEvolution(final @PathVariable int year) {
+      return ResponseEntity.ok(evolutionMetricsService.getDowningCustomerEvolution(year));
+   }
+
+   @GetMapping("/{year}/customers/joins")
+   public ResponseEntity<CustomerEvolutionResponse> getJoiningCustomersEvolution(final @PathVariable int year) {
+      return ResponseEntity.ok(evolutionMetricsService.getJoiningCustomerEvolution(year));
+   }
+
+   @GetMapping("/{year}/subscribers/joins")
+   public ResponseEntity<SubscriberEvolutionResponse> getJoiningSubscribersEvolution(final @PathVariable int year) {
+      return ResponseEntity.ok(evolutionMetricsService.getJoiningSubscriberEvolution(year));
+   }
+
+   @GetMapping("/{year}/subscribers/downs")
+   public ResponseEntity<SubscriberEvolutionResponse> getDowningSubscribersBeforeReachEndDate(final @PathVariable int year) {
+      return ResponseEntity.ok(evolutionMetricsService.getDowningSubscribersBeforeEndTime(year));
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/BillingEvolutionResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/BillingEvolutionResponse.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+
+import java.util.List;
+
+public record BillingEvolutionResponse(
+   @JsonProperty("content") List<MonthTotal> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/CustomerEvolutionResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/CustomerEvolutionResponse.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.CustomerEvolution;
+
+import java.util.List;
+
+public record CustomerEvolutionResponse(
+   @JsonProperty("content") List<CustomerEvolution> content
+   ) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriberEvolutionResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriberEvolutionResponse.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.SubscriberEvolution;
+
+import java.util.List;
+
+public record SubscriberEvolutionResponse(
+   @JsonProperty("content") List<SubscriberEvolution> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EvolutionMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EvolutionMetricsService.java
@@ -1,0 +1,17 @@
+package com.jame.dev.gymApp.features.metrics.application.contract;
+
+import com.jame.dev.gymApp.features.metrics.api.response.BillingEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.CustomerEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriberEvolutionResponse;
+
+public interface EvolutionMetricsService {
+   CustomerEvolutionResponse getJoiningCustomerEvolution(final long year);
+
+   CustomerEvolutionResponse getDowningCustomerEvolution(final long year);
+
+   SubscriberEvolutionResponse getJoiningSubscriberEvolution(final long year);
+
+   SubscriberEvolutionResponse getDowningSubscribersBeforeEndTime(final long year);
+
+   BillingEvolutionResponse getBillingEvolution(final long year);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EvolutionMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EvolutionMetricsApplicationService.java
@@ -1,0 +1,69 @@
+package com.jame.dev.gymApp.features.metrics.application.service;
+
+import com.jame.dev.gymApp.features.metrics.api.response.BillingEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.CustomerEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriberEvolutionResponse;
+import com.jame.dev.gymApp.features.metrics.application.contract.EvolutionMetricsService;
+import com.jame.dev.gymApp.features.metrics.domain.repository.EvolutionMetricsRepository;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EvolutionMetricsApplicationService implements EvolutionMetricsService {
+   private final EvolutionMetricsRepository evolutionMetricsRepository;
+
+   @Override
+   @Cacheable(
+      value = CacheEvolutionMetricsValues.JOINING_CUSTOMERS,
+      key = "#year",
+      unless = "#result == null"
+   )
+   public CustomerEvolutionResponse getJoiningCustomerEvolution(long year) {
+      return new CustomerEvolutionResponse(evolutionMetricsRepository.calculateJoiningCustomerEvolution(year));
+   }
+
+   @Override
+   @Cacheable(
+      value = CacheEvolutionMetricsValues.DOWNING_CUSTOMERS,
+      key = "#year",
+      unless = "#result == null"
+   )
+   public CustomerEvolutionResponse getDowningCustomerEvolution(long year) {
+      return new CustomerEvolutionResponse(evolutionMetricsRepository.calculateDowningCustomerEvolution(year));
+   }
+
+   @Override
+   @Cacheable(
+      value = CacheEvolutionMetricsValues.JOINING_SUBSCRIBERS,
+      key = "#year",
+      unless = "#result == null"
+   )
+   public SubscriberEvolutionResponse getJoiningSubscriberEvolution(long year) {
+      return new SubscriberEvolutionResponse(evolutionMetricsRepository.calculateJoiningSubscriberEvolution(year));
+   }
+
+   @Override
+   @Cacheable(
+      value = CacheEvolutionMetricsValues.DOWNING_SUBSCRIBERS,
+      key = "#year",
+      unless = "#result == null"
+   )
+   public SubscriberEvolutionResponse getDowningSubscribersBeforeEndTime(long year) {
+      return new SubscriberEvolutionResponse(evolutionMetricsRepository.calculateDowningSubscribersBeforeEndTime(year));
+   }
+
+   @Override
+   @Cacheable(
+      value = CacheEvolutionMetricsValues.BILLINGS,
+      key = "#year",
+      unless = "#result == null"
+   )
+   public BillingEvolutionResponse getBillingEvolution(long year) {
+      return new BillingEvolutionResponse(evolutionMetricsRepository.calculateBillingEvolution(year));
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/CustomerEvolution.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/CustomerEvolution.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.features.metrics.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CustomerEvolution(
+   @JsonProperty("month") String month,
+   @JsonProperty("customersNum") long customersNum
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/SubscriberEvolution.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/model/SubscriberEvolution.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.features.metrics.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SubscriberEvolution(
+   @JsonProperty("month") String month,
+   @JsonProperty("subscribersNum") long subscribersNum
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EvolutionMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EvolutionMetricsRepository.java
@@ -1,0 +1,20 @@
+package com.jame.dev.gymApp.features.metrics.domain.repository;
+
+import com.jame.dev.gymApp.features.metrics.domain.model.CustomerEvolution;
+import com.jame.dev.gymApp.features.metrics.domain.model.SubscriberEvolution;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+
+import java.util.List;
+
+public interface EvolutionMetricsRepository {
+
+   List<CustomerEvolution> calculateJoiningCustomerEvolution(final long year);
+
+   List<CustomerEvolution> calculateDowningCustomerEvolution(final long year);
+
+   List<SubscriberEvolution> calculateJoiningSubscriberEvolution(final long year);
+
+   List<SubscriberEvolution> calculateDowningSubscribersBeforeEndTime(final long year);
+
+   List<MonthTotal> calculateBillingEvolution(final long year);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheEvolutionMetricsValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheEvolutionMetricsValues.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.cache;
+
+public class CacheEvolutionMetricsValues {
+   public static final String JOINING_CUSTOMERS = "evolution:joiningCustomers";
+   public static final String DOWNING_CUSTOMERS = "evolution:downingCustomers";
+   public static final String JOINING_SUBSCRIBERS = "evolution:joiningSubscribers";
+   public static final String DOWNING_SUBSCRIBERS = "evolution:joiningSubscribers";
+   public static final String BILLINGS = "evolution:billings";
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/query/EvolutionMetricsRepositorySqlAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/query/EvolutionMetricsRepositorySqlAdapter.java
@@ -1,0 +1,156 @@
+package com.jame.dev.gymApp.features.metrics.infrastructure.query;
+
+import com.jame.dev.gymApp.features.metrics.domain.model.CustomerEvolution;
+import com.jame.dev.gymApp.features.metrics.domain.model.SubscriberEvolution;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+import com.jame.dev.gymApp.features.metrics.domain.repository.EvolutionMetricsRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Tuple;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class EvolutionMetricsRepositorySqlAdapter implements EvolutionMetricsRepository {
+
+   @PersistenceContext
+   private final EntityManager em;
+
+   @Override
+   public List<CustomerEvolution> calculateJoiningCustomerEvolution(final long year) {
+      final String sql = """
+            SELECT
+             TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
+             COUNT(c.id) AS customersNum
+         FROM generate_series(1, 12) AS m(month_number)
+         LEFT JOIN customers c
+             ON EXTRACT(MONTH FROM c.created_at) = m.month_number
+             AND EXTRACT(YEAR FROM c.created_at) = :year
+         GROUP BY m.month_number
+         ORDER BY m.month_number
+         """;
+      @SuppressWarnings("unchecked") final List<Tuple> rows = em.createNativeQuery(sql, Tuple.class)
+         .setParameter("year", year)
+         .getResultList();
+
+      return rows.stream()
+         .map(row -> new CustomerEvolution(
+            row.get("month", String.class),
+            row.get("customersNum", Long.class)
+         ))
+         .toList();
+   }
+
+   @Override
+   public List<CustomerEvolution> calculateDowningCustomerEvolution(final long year) {
+      final String sql = """
+            SELECT
+             TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
+             COUNT(c.id) AS customersNum
+         FROM generate_series(1, 12) AS m(month_number)
+         LEFT JOIN customers c
+             ON EXTRACT(MONTH FROM c.deleted_at) = m.month_number
+             AND EXTRACT(YEAR FROM c.deleted_at) = :year
+         GROUP BY m.month_number
+         ORDER BY m.month_number
+         """;
+      @SuppressWarnings("unchecked") final List<Tuple> rows = em.createNativeQuery(sql, Tuple.class)
+         .setParameter("year", year)
+         .getResultList();
+
+      return rows.stream()
+         .map(row -> new CustomerEvolution(
+            row.get("month", String.class),
+            row.get("customersNum", Long.class)
+         ))
+         .toList();
+   }
+
+   @Override
+   public List<SubscriberEvolution> calculateJoiningSubscriberEvolution(final long year) {
+      final String sql = """
+            SELECT
+             TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
+             COUNT(s.id) AS subscriptionsNum
+         FROM generate_series(1, 12) AS m(month_number)
+         LEFT JOIN subscriptions s
+             ON EXTRACT(MONTH FROM s.created_at) = m.month_number
+             AND s.paid = true
+             AND EXTRACT(YEAR FROM s.created_at) = :year
+         GROUP BY m.month_number
+         ORDER BY m.month_number
+         """;
+      @SuppressWarnings("unchecked") final List<Tuple> rows = em.createNativeQuery(sql, Tuple.class)
+         .setParameter("year", year)
+         .getResultList();
+
+      return rows.stream()
+         .map(row -> new SubscriberEvolution(
+            row.get("month", String.class),
+            row.get("subscriptionsNum", Long.class)
+         ))
+         .toList();
+   }
+
+   @Override
+   public List<SubscriberEvolution> calculateDowningSubscribersBeforeEndTime(long year) {
+      final String sql = """
+         SELECT
+             TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
+             COUNT(DISTINCT s.id) AS subscriptionsNum
+         FROM generate_series(1, 12) AS m(month_number)
+         LEFT JOIN subscriptions s
+             ON EXTRACT(MONTH FROM s.created_at) = m.month_number
+             AND s.paid = true
+             AND (s.finished = true OR s.active = false)
+             AND EXTRACT(YEAR FROM s.created_at) = :year
+         LEFT JOIN
+             subscription_periods sp ON sp.subscription_id = s.id
+         LEFT JOIN
+             periods p ON p.id = sp.period_id AND
+             p.end_period - p.start_period > 0
+         GROUP by m.month_number
+         ORDER BY m.month_number
+         """;
+      @SuppressWarnings("unchecked") final List<Tuple> rows = em.createNativeQuery(sql, Tuple.class)
+         .setParameter("year", year)
+         .getResultList();
+      return rows.stream()
+         .map(
+            r -> new SubscriberEvolution(
+               r.get("month", String.class),
+               r.get("subscriptionsNum", Long.class))
+         )
+         .toList();
+   }
+
+   @Override
+   public List<MonthTotal> calculateBillingEvolution(final long year) {
+      final String sql = """
+         SELECT
+             TO_CHAR(MAKE_DATE(EXTRACT(YEAR FROM CURRENT_DATE)::int, m.month_number, 1), 'Mon') AS month,
+             COALESCE(SUM(p.amount), 0) AS total
+         FROM generate_series(1, 12) AS m(month_number)
+         LEFT JOIN payments p
+             ON EXTRACT(MONTH FROM p.created_at) = m.month_number
+             AND p.amount > 0
+             AND EXTRACT(YEAR FROM p.created_at) = :year
+         GROUP BY m.month_number
+         ORDER BY m.month_number
+         """;
+      @SuppressWarnings("unchecked") final List<Tuple> rows = em.createNativeQuery(sql, Tuple.class)
+         .setParameter("year", year)
+         .getResultList();
+
+      return rows.stream()
+         .map(row -> new MonthTotal(
+            row.get("month", String.class),
+            row.get("total", BigDecimal.class)
+         ))
+         .toList();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
@@ -3,6 +3,7 @@ package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.domain.exception.EntityNotFoundException;
 import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictPaymentMetrics;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CompletedCheckoutUseCase;
 import com.jame.dev.gymApp.features.subscription.domain.event.CompletedCheckoutEvent;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
@@ -32,9 +33,11 @@ public class CompletedCheckoutUseCaseService implements CompletedCheckoutUseCase
    @Transactional
    @Caching(
       evict = {
-         @CacheEvict(value = CacheValues.SUBSCRIPTIONS, allEntries = true),
-         @CacheEvict(value = CacheValues.SUBSCRIPTION, allEntries = true),
-         @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true)
+         @CacheEvict(value = CacheValues.SUBSCRIPTIONS, allEntries = true, cacheManager = "redisCacheManager"),
+         @CacheEvict(value = CacheValues.SUBSCRIPTION, allEntries = true, cacheManager = "redisCacheManager"),
+         @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true, cacheManager = "redisCacheManager"),
+         @CacheEvict(value = CacheEvolutionMetricsValues.JOINING_SUBSCRIBERS, allEntries = true, cacheManager = "redisCacheManager"),
+         @CacheEvict(value = CacheEvolutionMetricsValues.BILLINGS, allEntries = true, cacheManager = "redisCacheManager")
       }
    )
    @EvictPaymentMetrics

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreatePaymentUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreatePaymentUseCaseService.java
@@ -2,6 +2,7 @@ package com.jame.dev.gymApp.features.subscription.application.service.mutation;
 
 import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictPaymentMetrics;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.subscription.api.request.PaymentRequest;
 import com.jame.dev.gymApp.features.subscription.application.support.factory.PaymentFactory;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreatePaymentUseCase;
@@ -13,6 +14,7 @@ import com.jame.dev.gymApp.features.subscription.domain.repository.PaymentMutati
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +27,12 @@ public class CreatePaymentUseCaseService implements CreatePaymentUseCase {
 
    @Override
    @Transactional
-   @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true)
+   @Caching(
+      evict = {
+         @CacheEvict(value = CacheValues.PAYMENTS, allEntries = true, cacheManager = "redisCacheManger"),
+         @CacheEvict(value = CacheEvolutionMetricsValues.BILLINGS, allEntries = true, cacheManager = "redisCacheManager")
+      }
+   )
    @EvictPaymentMetrics
    public void create(PaymentRequest paymentRequest) {
       final SubscriptionEntity subscriptionEntity = subscriptionQueryRepository.findById(paymentRequest.subscriptionId())

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreateSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CreateSubscriptionUseCaseService.java
@@ -9,6 +9,7 @@ import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
 import com.jame.dev.gymApp.features.customer.domain.repository.CustomerQueryRepository;
 import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictEarningMetrics;
 import com.jame.dev.gymApp.features.metrics.infrastructure.annotations.EvictSubscriptionMetrics;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
@@ -22,6 +23,7 @@ import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionV
 import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.PricingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,40 +34,45 @@ import static com.jame.dev.gymApp.application.model.CacheValues.SUBSCRIPTIONS;
 @Service
 @RequiredArgsConstructor
 public class CreateSubscriptionUseCaseService implements CreateSubscriptionUseCase {
-    private final SubscriptionMutationRepository subscriptionMutationRepository;
-    private final CustomerQueryRepository customerQueryRepository;
-    private final PricingRepository pricingRepository;
-    private final SubscriptionValidationRepository subscriptionValidationRepository;
-    private final SubscriptionFactory subscriptionFactory;
+   private final SubscriptionMutationRepository subscriptionMutationRepository;
+   private final CustomerQueryRepository customerQueryRepository;
+   private final PricingRepository pricingRepository;
+   private final SubscriptionValidationRepository subscriptionValidationRepository;
+   private final SubscriptionFactory subscriptionFactory;
 
-    @Override
-    @Transactional
-    @CacheEvict(value = SUBSCRIPTIONS, allEntries = true)
-    @EvictEarningMetrics
-    @EvictSubscriptionMetrics
-    @AuditLog(
-        action = AuditLogAction.INSERT,
-        entityType = AuditLogEntityType.SUBSCRIPTION,
-        input = "#request",
-        entityId = "#result.id",
-        result = "#result"
-    )
-    public SubscriptionResponse create(SubscriptionRequest request) {
-        final CustomerEntity customer = customerQueryRepository.findByUserEmail(request.customerEmail())
-            .orElseThrow(() -> new CustomerNotFoundException("Customer Not Found."));
+   @Override
+   @Transactional
+   @Caching(
+      evict = {
+         @CacheEvict(value = SUBSCRIPTIONS, allEntries = true, cacheManager = "redisCacheManager"),
+         @CacheEvict(value = CacheEvolutionMetricsValues.JOINING_SUBSCRIBERS, allEntries = true, cacheManager = "redisCacheManager"),
+      }
+   )
+   @EvictEarningMetrics
+   @EvictSubscriptionMetrics
+   @AuditLog(
+      action = AuditLogAction.INSERT,
+      entityType = AuditLogEntityType.SUBSCRIPTION,
+      input = "#request",
+      entityId = "#result.id",
+      result = "#result"
+   )
+   public SubscriptionResponse create(SubscriptionRequest request) {
+      final CustomerEntity customer = customerQueryRepository.findByUserEmail(request.customerEmail())
+         .orElseThrow(() -> new CustomerNotFoundException("Customer Not Found."));
 
-        if (subscriptionValidationRepository.existsByCustomer(customer)) {
-            throw new AlreadyExistsException("There's a subscription linked to the customer with: " + request.customerEmail());
-        }
+      if (subscriptionValidationRepository.existsByCustomer(customer)) {
+         throw new AlreadyExistsException("There's a subscription linked to the customer with: " + request.customerEmail());
+      }
 
-        final PricingEntity pricing = pricingRepository.findByMemberShipEntity_Membership(request.membership())
-            .orElseThrow(() -> new PricingNotFoundException("Pricing Not Found."));
+      final PricingEntity pricing = pricingRepository.findByMemberShipEntity_Membership(request.membership())
+         .orElseThrow(() -> new PricingNotFoundException("Pricing Not Found."));
 
-        final SubscriptionEntity subscriptionEntity = subscriptionFactory.createFromInput(
-            new SubscriptionFactoryDtoInput(customer, pricing, LocalDate.now()));
+      final SubscriptionEntity subscriptionEntity = subscriptionFactory.createFromInput(
+         new SubscriptionFactoryDtoInput(customer, pricing, LocalDate.now()));
 
-        final SubscriptionEntity subscriptionSaved = subscriptionMutationRepository.save(subscriptionEntity);
+      final SubscriptionEntity subscriptionSaved = subscriptionMutationRepository.save(subscriptionEntity);
 
-        return subscriptionFactory.createFromEntity(subscriptionSaved);
-    }
+      return subscriptionFactory.createFromEntity(subscriptionSaved);
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
@@ -4,6 +4,7 @@ import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.FinalizeSubscriptionUseCase;
@@ -38,8 +39,10 @@ public class FinalizeSubscriptionUseCaseService implements FinalizeSubscriptionU
    @CacheEvictSubscriptions
    @Caching(evict = {
       @CacheEvict(
-         value = CacheValues.PAYMENTS, allEntries = true,
-         cacheManager = "redisCacheManager"
+         value = CacheValues.PAYMENTS, allEntries = true, cacheManager = "redisCacheManager"
+      ),
+      @CacheEvict(
+         value = CacheEvolutionMetricsValues.DOWNING_SUBSCRIBERS, allEntries = true, cacheManager = "redisCacheManager"
       )
    })
    @AuditLog(
@@ -50,23 +53,19 @@ public class FinalizeSubscriptionUseCaseService implements FinalizeSubscriptionU
    )
    public SubscriptionResponse finalize(long id) {
       final Instant updatedAt = Instant.now();
-      log.info("[HIT]: finalize use case.");
       final SubscriptionEntity subscription = subscriptionQueryRepository.findById(id)
          .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not Found."));
-      log.info("Subscription retrieved.");
+
       Optional.ofNullable(subscription.getPayments())
          .filter(Predicate.not(List::isEmpty))
          .map(List::getLast)
          .ifPresent(p -> {
             p.setStatus(PaymentStatus.FINALIZED);
             p.setUpdatedAt(updatedAt);
-            //p.setActive(false);
-            log.info("check payment.");
          });
 
       subscription.setFinished(true);
       subscription.setUpdatedAt(updatedAt);
-      log.info("subscription updated.");
       return subscriptionFactory.createFromEntity(subscriptionMutationRepository.save(subscription));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/SoftDeleteSubscriptionByIdUseCaseService.java
@@ -4,6 +4,7 @@ import com.jame.dev.gymApp.application.model.CacheValues;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.SoftDeleteSubscriptionByIdUseCase;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
 import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
@@ -22,12 +23,17 @@ public class SoftDeleteSubscriptionByIdUseCaseService implements SoftDeleteSubsc
    @Transactional
    @CacheEvictSubscriptions
    @Caching(
-      evict = @CacheEvict(
-         value = CacheValues.PAYMENTS,
-         allEntries = true,
-         cacheManager = "redisCacheManager",
-         beforeInvocation = true
-      )
+      evict = {
+         @CacheEvict(
+            value = CacheValues.PAYMENTS,
+            allEntries = true,
+            cacheManager = "redisCacheManager",
+            beforeInvocation = true
+         ),
+         @CacheEvict(
+            value = CacheEvolutionMetricsValues.DOWNING_SUBSCRIBERS, allEntries = true, cacheManager = "redisCacheManager"
+         )
+      }
    )
    @AuditLog(
       action = AuditLogAction.DELETE,

--- a/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/RedisConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/RedisConfig.java
@@ -29,8 +29,6 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
-import java.util.Collection;
-import java.util.Map;
 
 @Slf4j
 @Configuration
@@ -114,13 +112,13 @@ public class RedisConfig {
 
 
    private void registerMixIns(ObjectMapper mapper) {
-      ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+      final ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
       scanner.addIncludeFilter(new AssignableTypeFilter(Object.class));
 
       scanner.findCandidateComponents("com.jame.dev.gymApp").forEach(beanDefinition -> {
          try {
-            Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
-            if (clazz.isRecord() || clazz.isAssignableFrom(Map.class) || clazz.isAssignableFrom(Collection.class)) {
+            final Class<?> clazz = Class.forName(beanDefinition.getBeanClassName());
+            if (clazz.isRecord()) {
                mapper.addMixIn(clazz, DefaultMixInDto.class);
             }
          } catch (ClassNotFoundException e) {


### PR DESCRIPTION
# Description

This pull request introduces a dedicated **Evolution Metrics** backend feature responsible for exposing historical application metrics related to Customers, Subscribers, and Billings. It adds a new repository implementation with optimized native SQL queries, a service layer with Redis caching, and administrative REST endpoints that provide monthly evolution data for analytical dashboards.

# Main Changes

- Created the new **EvolutionMetricsRepository** abstraction and its SQL adapter implementation dedicated to retrieving historical evolution metrics.
- Implemented native SQL queries to calculate:
  - Customer joining evolution.
  - Customer downing evolution.
  - Subscriber joining evolution.
  - Subscriber downing before the subscription end period.
  - Monthly billing evolution.
- Added the **EvolutionMetricsApplicationService** to orchestrate evolution metrics retrieval.
- Exposed new administrative REST endpoints through **EvolutionMetricsController** for all evolution metrics.
- Added dedicated API response DTOs for customer, subscriber, and billing evolution responses.
- Introduced new domain models representing customer and subscriber evolution records.
- Implemented Redis cache support for evolution metrics with dedicated cache namespaces.
- Integrated cache invalidation into customer, subscription, and payment mutation use cases to keep evolution metrics synchronized with application state.
- Added automatic `deletedAt` timestamp assignment using `@PreRemove` to improve deletion tracking and support historical downing metrics.

# Minimal Changes

- Refactored cache eviction annotations to use grouped `@Caching` declarations where appropriate.
- Standardized Redis cache manager usage across mutation services.
- Removed unnecessary logging statements from subscription finalization.
- Simplified Redis MixIn registration by limiting it to Java records only.
- Improved formatting, consistency, and readability across service and repository implementations.
- Added dedicated cache constants for evolution metrics.

# Notes

- The repository currently relies on PostgreSQL-specific features such as `generate_series` and `MAKE_DATE`; migrating to another database engine may require query adaptations.
- Redis cache invalidation has been integrated into all relevant mutations to ensure analytical data remains consistent after customer, subscription, and payment changes.
- The new architecture allows additional historical metrics to be incorporated by extending the repository and service layers while reusing the existing controller pattern.
- Future improvements could include configurable date ranges, custom aggregation intervals (weekly, quarterly), and comparative analytics between multiple years.