### PR TITLE
Metrics Deserialization

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/customer/application/service/mutation/SoftDeleteCustomerByIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/customer/application/service/mutation/SoftDeleteCustomerByIdUseCaseService.java
@@ -6,24 +6,32 @@ import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
 import com.jame.dev.gymApp.features.customer.application.usecases.mutation.SoftDeleteCustomerByIdUseCase;
 import com.jame.dev.gymApp.features.customer.domain.repository.CustomerMutationRepository;
 import com.jame.dev.gymApp.features.customer.infrastructure.annotations.CacheEvictCustomers;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class SoftDeleteCustomerByIdUseCaseService implements SoftDeleteCustomerByIdUseCase {
-    private final CustomerMutationRepository customerMutationRepository;
+   private final CustomerMutationRepository customerMutationRepository;
 
-    @Override
-    @Transactional
-    @CacheEvictCustomers
-    @AuditLog(
-        action = AuditLogAction.DELETE,
-        entityType = AuditLogEntityType.CUSTOMER,
-        entityId = "#id"
-    )
-    public void softDeleteById(long id) {
-        customerMutationRepository.deleteById(id);
-    }
+   @Override
+   @Transactional
+   @CacheEvictCustomers
+   @Caching(
+      evict = {
+         @CacheEvict(value = CacheEvolutionMetricsValues.DOWNING_CUSTOMERS, allEntries = true, cacheManager = "redisCacheManager")
+      }
+   )
+   @AuditLog(
+      action = AuditLogAction.DELETE,
+      entityType = AuditLogEntityType.CUSTOMER,
+      entityId = "#id"
+   )
+   public void softDeleteById(long id) {
+      customerMutationRepository.deleteById(id);
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/EarningMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/EarningMetricsController.java
@@ -1,17 +1,15 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningByYearResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMembershipTypeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMonthResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningsResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
-import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
-import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/app/v1/administration/metrics/earnings")
@@ -25,17 +23,17 @@ public class EarningMetricsController {
    }
 
    @GetMapping("/months")
-   public ResponseEntity<List<TotalPerMonthResponse>> getTotalPerMonth() {
+   public ResponseEntity<EarningsByMonthResponse> getTotalPerMonth() {
       return ResponseEntity.ok(service.getTotalPerMonth());
    }
 
    @GetMapping("/memberships")
-   public ResponseEntity<List<TotalPerMembershipTypeDto>> getTotalPerMembershipType() {
+   public ResponseEntity<EarningsByMembershipTypeResponse> getTotalPerMembershipType() {
       return ResponseEntity.ok(service.getTotalPerMembershipType());
    }
 
    @GetMapping("/rankings/periods")
-   public ResponseEntity<List<PeriodicalEarningByYearResponse>> getPeriodicalEarningsByYearRanking() {
+   public ResponseEntity<PeriodicalEarningsResponse> getPeriodicalEarningsByYearRanking() {
       return ResponseEntity.ok(service.getPeriodicalEarnings());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentAdminMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentAdminMetricsController.java
@@ -1,16 +1,14 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.InvestmentMonthEvolutionResponse;
 import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsAdminService;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/app/v1/administration/metrics/payments")
@@ -26,7 +24,7 @@ public class PaymentAdminMetricsController {
    }
 
    @GetMapping("/evolution")
-   public ResponseEntity<List<MonthTotal>> getMonthInvestmentEvolution() {
+   public ResponseEntity<InvestmentMonthEvolutionResponse> getMonthInvestmentEvolution() {
       return ResponseEntity.ok(paymentMetricsAdminService.getInvestmentMonthEvolution());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentSubscriberMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/PaymentSubscriberMetricsController.java
@@ -1,9 +1,9 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.InvestmentMonthEvolutionResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
 import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsSubscriberService;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -11,8 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RequestMapping("/app/v1/subscribers/metrics")
 @RestController
@@ -40,7 +38,7 @@ public class PaymentSubscriberMetricsController {
 
    @PreAuthorize("@customerSecurity.isOwner(#customerId, authentication)")
    @GetMapping("/{customerId}/evolution")
-   public ResponseEntity<List<MonthTotal>> getMonthInvestmentEvolution(
+   public ResponseEntity<InvestmentMonthEvolutionResponse> getMonthInvestmentEvolution(
       @PathVariable("customerId") long customerId
    ) {
       return ResponseEntity.ok(paymentMetricsService.getInvestmentMonthEvolution(customerId));

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
@@ -1,11 +1,11 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
-import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingPerYear;
+import com.jame.dev.gymApp.features.metrics.api.response.MembershipRankingsResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingsResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMembershipResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
-import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
-import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/app/v1/administration/metrics/subs")
@@ -29,12 +28,12 @@ public class SubscriptionMetricsController {
    }
 
    @GetMapping("/rankings/memberships")
-   public ResponseEntity<List<MembershipRanking>> getMembershipRankings() {
+   public ResponseEntity<MembershipRankingsResponse> getMembershipRankings() {
       return ResponseEntity.ok(service.getMembershipRanking());
    }
 
    @GetMapping("/rankings/periods")
-   public ResponseEntity<List<PeriodRankingPerYear>> getPeriodRankings() {
+   public ResponseEntity<PeriodRankingsResponse> getPeriodRankings() {
       return ResponseEntity.ok(service.getPeriodRanking());
    }
 
@@ -44,12 +43,12 @@ public class SubscriptionMetricsController {
    }
 
    @GetMapping("/memberships")
-   public ResponseEntity<List<SubsPerMembership>> getSubsPerMembership() {
+   public ResponseEntity<SubscriptionsPerMembershipResponse> getSubsPerMembership() {
       return ResponseEntity.ok(service.getSubscriptionsPerMembership());
    }
 
    @GetMapping("/months")
-   public ResponseEntity<List<SubsPerMonthDto>> getSubsPerMonth() {
+   public ResponseEntity<SubscriptionsPerMonthResponse> getSubsPerMonth() {
       return ResponseEntity.ok(service.getSubscriptionsPerMonth());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/EarningsByMembershipTypeResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/EarningsByMembershipTypeResponse.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
+
+import java.util.List;
+
+public record EarningsByMembershipTypeResponse(
+   @JsonProperty("content") List<TotalPerMembershipTypeDto> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/EarningsByMonthResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/EarningsByMonthResponse.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record EarningsByMonthResponse(
+   @JsonProperty("content") List<TotalPerMonthResponse> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/InvestmentMonthEvolutionResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/InvestmentMonthEvolutionResponse.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
+
+import java.util.List;
+
+public record InvestmentMonthEvolutionResponse(
+   @JsonProperty("content") List<MonthTotal> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/MembershipRankingsResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/MembershipRankingsResponse.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record MembershipRankingsResponse(
+   @JsonProperty("content") List<MembershipRanking> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodRankingsResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodRankingsResponse.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record PeriodRankingsResponse(
+   @JsonProperty("content") List<PeriodRankingPerYear> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodicalEarningsResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/PeriodicalEarningsResponse.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record PeriodicalEarningsResponse(
+   @JsonProperty("content") List<PeriodicalEarningByYearResponse> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriptionsPerMembershipResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriptionsPerMembershipResponse.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
+
+import java.util.List;
+
+public record SubscriptionsPerMembershipResponse(
+   @JsonProperty("content") List<SubsPerMembership> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriptionsPerMonthResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriptionsPerMonthResponse.java
@@ -1,0 +1,11 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
+
+import java.util.List;
+
+public record SubscriptionsPerMonthResponse(
+   @JsonProperty("content") List<SubsPerMonthDto> content
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EarningMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/EarningMetricsService.java
@@ -1,18 +1,16 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningByYearResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMembershipTypeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMonthResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningsResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
-import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
-import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
-
-import java.util.List;
 
 public interface EarningMetricsService {
    TotalEarned getTotal();
 
-   List<TotalPerMonthResponse> getTotalPerMonth();
+   EarningsByMonthResponse getTotalPerMonth();
 
-   List<TotalPerMembershipTypeDto> getTotalPerMembershipType();
+   EarningsByMembershipTypeResponse getTotalPerMembershipType();
 
-   List<PeriodicalEarningByYearResponse> getPeriodicalEarnings();
+   PeriodicalEarningsResponse getPeriodicalEarnings();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsAdminService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsAdminService.java
@@ -1,13 +1,11 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
-
-import java.util.List;
+import com.jame.dev.gymApp.features.metrics.api.response.InvestmentMonthEvolutionResponse;
 
 public interface PaymentMetricsAdminService {
 
    AnnualResumeResponse getAnnualResume();
 
-   List<MonthTotal> getInvestmentMonthEvolution();
+   InvestmentMonthEvolutionResponse getInvestmentMonthEvolution();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsSubscriberService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/PaymentMetricsSubscriberService.java
@@ -1,15 +1,13 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.InvestmentMonthEvolutionResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
-
-import java.util.List;
 
 public interface PaymentMetricsSubscriberService {
 
    TotalInvestment getTotalExpend(final long customerId);
    AnnualResumeResponse getAnnualResume(final long customerId);
-   List<MonthTotal> getInvestmentMonthEvolution(final long customerId);
+   InvestmentMonthEvolutionResponse getInvestmentMonthEvolution(final long customerId);
 
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
@@ -1,25 +1,24 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
-import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingPerYear;
+import com.jame.dev.gymApp.features.metrics.api.response.MembershipRankingsResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingsResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMembershipResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
-import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
-import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import lombok.NonNull;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public interface SubscriptionMetricsService {
    TotalSubscriptions getTotalSubscriptions();
 
-   List<MembershipRanking> getMembershipRanking();
+   MembershipRankingsResponse getMembershipRanking();
 
-   List<PeriodRankingPerYear> getPeriodRanking();
+   PeriodRankingsResponse getPeriodRanking();
 
    TotalSubscriptions getSubscriptionsBefore(@NonNull final LocalDate date);
 
-   List<SubsPerMonthDto> getSubscriptionsPerMonth();
+   SubscriptionsPerMonthResponse getSubscriptionsPerMonth();
 
-   List<SubsPerMembership> getSubscriptionsPerMembership();
+   SubscriptionsPerMembershipResponse getSubscriptionsPerMembership();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/EarningMetricsApplicationService.java
@@ -1,8 +1,6 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodicalEarningByYearResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
-import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.*;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.*;
 import com.jame.dev.gymApp.features.metrics.domain.repository.EarningMetricsRepository;
@@ -33,59 +31,61 @@ public class EarningMetricsApplicationService implements EarningMetricsService {
    @Override
    @Cacheable(
       value = CacheEarningMetricValues.EARNING_PER_MONTH,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<TotalPerMonthResponse> getTotalPerMonth() {
-      final List<TotalPerMonth> totalPerMonthDtoList = repo.calculateTotalPerMonth();
-      return totalPerMonthDtoList.stream()
-         .collect(Collectors.groupingBy(
-            TotalPerMonth::year,
-            Collectors.mapping(
-               dto ->
-                  new MonthTotal(dto.month(), dto.total()),
-               Collectors.toUnmodifiableList()
-            )
-         ))
-         .entrySet()
-         .stream()
-         .map(entry -> new TotalPerMonthResponse(entry.getKey(), entry.getValue()))
-         .toList();
+   public EarningsByMonthResponse getTotalPerMonth() {
+      return new EarningsByMonthResponse(
+         repo.calculateTotalPerMonth().stream()
+            .collect(Collectors.groupingBy(
+               TotalPerMonth::year,
+               Collectors.mapping(
+                  dto -> new MonthTotal(dto.month(), dto.total()),
+                  Collectors.toUnmodifiableList()
+               )
+            ))
+            .entrySet()
+            .stream()
+            .map(entry -> new TotalPerMonthResponse(entry.getKey(), entry.getValue()))
+            .toList()
+      );
    }
 
    @Override
    @Cacheable(
       value = CacheEarningMetricValues.EARNING_MEMBERSHIP_TYPE,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<TotalPerMembershipTypeDto> getTotalPerMembershipType() {
-      final List<TotalPerMembershipTypeDto> dtoList = repo.calculateTotalPerMembership();
-      return dtoList.isEmpty() ? List.of() : dtoList;
+   public EarningsByMembershipTypeResponse getTotalPerMembershipType() {
+      final var dtoList = repo.calculateTotalPerMembership();
+      return new EarningsByMembershipTypeResponse(dtoList.isEmpty() ? List.of() : dtoList);
    }
 
    @Override
    @Cacheable(
       value = CacheEarningMetricValues.EARNING_PERIODICAL,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<PeriodicalEarningByYearResponse> getPeriodicalEarnings() {
-      return repo.calculatePeriodicalEarnings()
-         .stream()
-         .collect(
-            Collectors.groupingBy(
-               YearPeriodicalEarning::year,
-               Collectors.mapping(
-                  data -> PeriodicalEarning.builder()
-                     .totalEarned(data.totalEarned())
-                     .membership(data.membership())
-                     .period(data.period())
-                     .rank(data.rank())
-                     .build(),
-                  Collectors.toUnmodifiableList()
-               )
-            ))
-         .entrySet()
-         .stream()
-         .map(data -> new PeriodicalEarningByYearResponse(data.getKey(), data.getValue()))
-         .toList();
+   public PeriodicalEarningsResponse getPeriodicalEarnings() {
+      return new PeriodicalEarningsResponse(
+         repo.calculatePeriodicalEarnings()
+            .stream()
+            .collect(
+               Collectors.groupingBy(
+                  YearPeriodicalEarning::year,
+                  Collectors.mapping(
+                     data -> PeriodicalEarning.builder()
+                        .totalEarned(data.totalEarned())
+                        .membership(data.membership())
+                        .period(data.period())
+                        .rank(data.rank())
+                        .build(),
+                     Collectors.toUnmodifiableList()
+                  )
+               ))
+            .entrySet()
+            .stream()
+            .map(data -> new PeriodicalEarningByYearResponse(data.getKey(), data.getValue()))
+            .toList()
+      );
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsAdminApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsAdminApplicationService.java
@@ -1,15 +1,13 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.InvestmentMonthEvolutionResponse;
 import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsAdminService;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import com.jame.dev.gymApp.features.metrics.domain.repository.PaymentMetricsRepository;
 import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CachePaymentMetricsValues;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,9 +26,9 @@ public class PaymentMetricsAdminApplicationService implements PaymentMetricsAdmi
    @Override
    @Cacheable(
       value = CachePaymentMetricsValues.EVOLUTION,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<MonthTotal> getInvestmentMonthEvolution() {
-      return paymentMetricsRepository.calculatePaymentEvolutionAlongMonths();
+   public InvestmentMonthEvolutionResponse getInvestmentMonthEvolution() {
+      return new InvestmentMonthEvolutionResponse(paymentMetricsRepository.calculatePaymentEvolutionAlongMonths());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsSubscriberApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/PaymentMetricsSubscriberApplicationService.java
@@ -1,17 +1,15 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
 import com.jame.dev.gymApp.features.metrics.api.response.AnnualResumeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.InvestmentMonthEvolutionResponse;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalInvestment;
 import com.jame.dev.gymApp.features.metrics.application.contract.PaymentMetricsSubscriberService;
-import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import com.jame.dev.gymApp.features.metrics.domain.repository.PaymentMetricsRepository;
 import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CachePaymentMetricsValues;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 
 @Service
@@ -43,10 +41,10 @@ public class PaymentMetricsSubscriberApplicationService implements PaymentMetric
    @Override
    @Cacheable(
       value = CachePaymentMetricsValues.EVOLUTION,
-      unless = "#result == null || #result.isEmpty()",
+      unless = "#result == null || #result.content.isEmpty()",
       key = "#customerId"
    )
-   public List<MonthTotal> getInvestmentMonthEvolution(long customerId) {
-      return paymentMetricsRepository.calculatePaymentEvolutionAlongMonths(customerId);
+   public InvestmentMonthEvolutionResponse getInvestmentMonthEvolution(long customerId) {
+      return new InvestmentMonthEvolutionResponse(paymentMetricsRepository.calculatePaymentEvolutionAlongMonths(customerId));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
@@ -1,13 +1,9 @@
 package com.jame.dev.gymApp.features.metrics.application.service;
 
-import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingPerYear;
-import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
+import com.jame.dev.gymApp.features.metrics.api.response.*;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
 import com.jame.dev.gymApp.features.metrics.domain.model.PeriodRanking;
 import com.jame.dev.gymApp.features.metrics.domain.model.PeriodSubscribersRanking;
-import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
-import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import com.jame.dev.gymApp.features.metrics.domain.repository.SubscriptionMetricsRepository;
 import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheSubsMetricsValues;
 import lombok.NonNull;
@@ -17,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,35 +33,37 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
    @Override
    @Cacheable(
       value = CacheSubsMetricsValues.SUBSCRIPTION_RANKING,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<MembershipRanking> getMembershipRanking() {
-      return repo.calculateMembershipRanking();
+   public MembershipRankingsResponse getMembershipRanking() {
+      return new MembershipRankingsResponse(repo.calculateMembershipRanking());
    }
 
    @Override
    @Cacheable(
       value = CacheSubsMetricsValues.SUBSCRIPTION_PERIOD_RANKING,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<PeriodRankingPerYear> getPeriodRanking() {
-      return repo.calculatePeriodWithMostSubscribers()
-         .stream()
-         .collect(
-            Collectors.groupingBy(
-               PeriodSubscribersRanking::year,
-               Collectors.mapping(dto ->
-                     PeriodRanking.builder()
-                        .period(dto.period())
-                        .subscriptionType(dto.subscriptionType())
-                        .subscriptionCount(dto.subscriptionCount())
-                        .rank(dto.rank())
-                        .build(),
-                  Collectors.toUnmodifiableList())))
-         .entrySet()
-         .stream()
-         .map((map) -> new PeriodRankingPerYear(map.getKey(), map.getValue()))
-         .toList();
+   public PeriodRankingsResponse getPeriodRanking() {
+      return new PeriodRankingsResponse(
+         repo.calculatePeriodWithMostSubscribers()
+            .stream()
+            .collect(
+               Collectors.groupingBy(
+                  PeriodSubscribersRanking::year,
+                  Collectors.mapping(dto ->
+                        PeriodRanking.builder()
+                           .period(dto.period())
+                           .subscriptionType(dto.subscriptionType())
+                           .subscriptionCount(dto.subscriptionCount())
+                           .rank(dto.rank())
+                           .build(),
+                     Collectors.toUnmodifiableList())))
+            .entrySet()
+            .stream()
+            .map((map) -> new PeriodRankingPerYear(map.getKey(), map.getValue()))
+            .toList()
+      );
    }
 
    @Override
@@ -81,18 +78,18 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
    @Override
    @Cacheable(
       value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<SubsPerMonthDto> getSubscriptionsPerMonth() {
-      return repo.countSubsByMonth();
+   public SubscriptionsPerMonthResponse getSubscriptionsPerMonth() {
+      return new SubscriptionsPerMonthResponse(repo.countSubsByMonth());
    }
 
    @Override
    @Cacheable(
       value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MEMBERSHIP,
-      unless = "#result == null || #result.isEmpty()"
+      unless = "#result == null || #result.content.isEmpty()"
    )
-   public List<SubsPerMembership> getSubscriptionsPerMembership() {
-      return repo.countSubsByMembership();
+   public SubscriptionsPerMembershipResponse getSubscriptionsPerMembership() {
+      return new SubscriptionsPerMembershipResponse(repo.countSubsByMembership());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/user/application/service/mutation/HardDeleteUserByIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/application/service/mutation/HardDeleteUserByIdUseCaseService.java
@@ -3,10 +3,13 @@ package com.jame.dev.gymApp.features.user.application.service.mutation;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.user.application.usecases.mutation.HardDeleteUserByIdUseCase;
 import com.jame.dev.gymApp.features.user.domain.repository.UserMutationRepository;
 import com.jame.dev.gymApp.features.user.infrastructure.annotations.CacheEvictUsers;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,11 @@ public class HardDeleteUserByIdUseCaseService implements HardDeleteUserByIdUseCa
    @Override
    @Transactional
    @CacheEvictUsers
+   @Caching(
+      evict = {
+         @CacheEvict(value = CacheEvolutionMetricsValues.DOWNING_CUSTOMERS, allEntries = true, cacheManager = "redisCacheManager")
+      }
+   )
    @AuditLog(
       action = AuditLogAction.HARD_DELETE,
       entityType = AuditLogEntityType.USER,

--- a/src/main/java/com/jame/dev/gymApp/features/user/application/service/mutation/SoftDeleteUserByIdUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/application/service/mutation/SoftDeleteUserByIdUseCaseService.java
@@ -3,10 +3,13 @@ package com.jame.dev.gymApp.features.user.application.service.mutation;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
+import com.jame.dev.gymApp.features.metrics.infrastructure.cache.CacheEvolutionMetricsValues;
 import com.jame.dev.gymApp.features.user.application.usecases.mutation.SoftDeleteUserByIdUseCase;
 import com.jame.dev.gymApp.features.user.domain.repository.UserMutationRepository;
 import com.jame.dev.gymApp.features.user.infrastructure.annotations.CacheEvictUsers;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +21,11 @@ public class SoftDeleteUserByIdUseCaseService implements SoftDeleteUserByIdUseCa
    @Override
    @Transactional
    @CacheEvictUsers
+   @Caching(
+      evict = {
+         @CacheEvict(value = CacheEvolutionMetricsValues.DOWNING_CUSTOMERS, allEntries = true, cacheManager = "redisCacheManager")
+      }
+   )
    @AuditLog(
       action = AuditLogAction.DELETE,
       entityType = AuditLogEntityType.USER,

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/EarningMetricsControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/EarningMetricsControllerTest.java
@@ -4,6 +4,10 @@ import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthoriza
 import com.jame.dev.gymApp.features.metrics.api.EarningMetricsController;
 import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.features.metrics.application.contract.EarningMetricsService;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMembershipTypeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMonthResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalPerMonthResponse;
 import com.jame.dev.gymApp.features.metrics.domain.model.MonthTotal;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +23,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -47,7 +50,7 @@ class EarningMetricsControllerTest {
    @DisplayName("Should return the total earned.")
    void getTotalEarnings() throws Exception {
       final String URI = URI_TEMPLATE + "/total";
-      when(service.getTotal()).thenReturn(BigDecimal.valueOf(10_000d));
+      when(service.getTotal()).thenReturn(new TotalEarned(BigDecimal.valueOf(10_000d)));
 
       mockMvc.perform(get(URI)
                       .accept(MediaType.APPLICATION_JSON))
@@ -62,14 +65,15 @@ class EarningMetricsControllerTest {
    @DisplayName("Should return the list of months and his total earned.")
    void getTotalPerMonth() throws Exception {
       final String URI = URI_TEMPLATE + "/months";
-      var returnData = Map.of(2026, List.of(
-              new MonthTotal( "December", BigDecimal.valueOf(3_000d))));
+      var returnData = new EarningsByMonthResponse(List.of(
+              new TotalPerMonthResponse(2026, List.of(
+                      new MonthTotal("December", BigDecimal.valueOf(3_000d))))));
       when(service.getTotalPerMonth()).thenReturn(returnData);
 
       this.mockMvc.perform(get(URI)
                       .accept(MediaType.APPLICATION_JSON))
               .andExpect(status().isOk())
-              .andExpect(jsonPath("$.*").exists());
+              .andExpect(jsonPath("$.content").isArray());
       verify(service, atLeastOnce()).getTotalPerMonth();
       verifyNoMoreInteractions(service);
    }
@@ -78,14 +82,16 @@ class EarningMetricsControllerTest {
    @DisplayName("Should return the list of memberships and his total earned")
    void getTotalPerMembershipType() throws Exception {
       final String URI = URI_TEMPLATE + "/memberships";
-      when(service.getTotalPerMembershipType()).thenReturn(List.of(
-              new TotalPerMembershipTypeDto("MONTHLY", BigDecimal.valueOf(3_000d))
-      ));
+      when(service.getTotalPerMembershipType()).thenReturn(
+              new EarningsByMembershipTypeResponse(List.of(
+                      new TotalPerMembershipTypeDto("MONTHLY", BigDecimal.valueOf(3_000d))
+              ))
+      );
 
       this.mockMvc.perform(get(URI)
                       .accept(MediaType.APPLICATION_JSON))
               .andExpect(status().isOk())
-              .andExpect(jsonPath("$.[0]").exists());
+              .andExpect(jsonPath("$.content[0]").exists());
       verify(service, atLeastOnce()).getTotalPerMembershipType();
       verifyNoMoreInteractions(service);
    }

--- a/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionMetricsControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/controller/routes/app/admin/SubscriptionMetricsControllerTest.java
@@ -4,6 +4,9 @@ import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthoriza
 import com.jame.dev.gymApp.features.metrics.api.SubscriptionMetricsController;
 import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMembershipResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMonthResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import org.junit.jupiter.api.DisplayName;
@@ -46,7 +49,7 @@ class SubscriptionMetricsControllerTest {
    @DisplayName("Should return the total subscriptions active and unfinished.")
    void getTotalSubscriptions() throws Exception {
       final String URI = URI_TEMPLATE + "/totals";
-      when(service.getTotalSubscriptions()).thenReturn(10L);
+      when(service.getTotalSubscriptions()).thenReturn(new TotalSubscriptions(10L));
 
       mockMvc.perform(get(URI)
               .accept(MediaType.APPLICATION_JSON))
@@ -62,7 +65,7 @@ class SubscriptionMetricsControllerTest {
    void getTotalBefore() throws Exception {
       final String URI = URI_TEMPLATE + '/' + LocalDate.now() + "/before";
       when(service.getSubscriptionsBefore(any(LocalDate.class)))
-              .thenReturn(2L);
+              .thenReturn(new TotalSubscriptions(2L));
 
       mockMvc.perform(get(URI)
               .param("date", LocalDate.now().toString())
@@ -78,14 +81,14 @@ class SubscriptionMetricsControllerTest {
    @DisplayName("Should return a list of subs grouped by memberships.")
    void getSubsPerMembership() throws Exception {
       final String URI = URI_TEMPLATE + "/memberships";
-      when(service.getSubscriptionsPerMembership()).thenReturn(List.of(
-              new SubsPerMembership("MONTHLY", 2L)
-      ));
+      when(service.getSubscriptionsPerMembership()).thenReturn(
+              new SubscriptionsPerMembershipResponse(List.of(new SubsPerMembership("MONTHLY", 2L)))
+      );
 
       mockMvc.perform(get(URI)
               .accept(MediaType.APPLICATION_JSON))
               .andExpect(status().isOk())
-              .andExpect(jsonPath("$.[0]").exists());
+              .andExpect(jsonPath("$.content[0]").exists());
       verify(service, atLeastOnce()).getSubscriptionsPerMembership();
       verifyNoMoreInteractions(service);
    }
@@ -94,14 +97,14 @@ class SubscriptionMetricsControllerTest {
    @DisplayName("Should return a list of subs grouped by months.")
    void getSubsPerMonth() throws Exception {
       final String URI = URI_TEMPLATE + "/months";
-      when(service.getSubscriptionsPerMonth()).thenReturn(List.of(
-              new SubsPerMonthDto("December", 10L)
-      ));
+      when(service.getSubscriptionsPerMonth()).thenReturn(
+              new SubscriptionsPerMonthResponse(List.of(new SubsPerMonthDto("December", 10L)))
+      );
 
       mockMvc.perform(get(URI)
               .accept(MediaType.APPLICATION_JSON))
               .andExpect(status().isOk())
-              .andExpect(jsonPath("$.[0]").exists());
+              .andExpect(jsonPath("$.content[0]").exists());
       verify(service, atLeastOnce()).getSubscriptionsPerMonth();
       verifyNoMoreInteractions(service);
    }

--- a/src/test/java/com/jame/dev/gymApp/metrics/service/EarningMetricsServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/metrics/service/EarningMetricsServiceTest.java
@@ -2,6 +2,9 @@ package com.jame.dev.gymApp.metrics.service;
 
 import com.jame.dev.gymApp.features.metrics.domain.repository.EarningMetricsRepository;
 import com.jame.dev.gymApp.features.metrics.application.service.EarningMetricsApplicationService;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMembershipTypeResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.EarningsByMonthResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalEarned;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMembershipTypeDto;
 import com.jame.dev.gymApp.features.metrics.domain.model.TotalPerMonth;
 import org.junit.jupiter.api.DisplayName;
@@ -31,15 +34,15 @@ public class EarningMetricsServiceTest {
    @DisplayName("Should get the total earned")
    void getAllEarnings(){
       when(repo.calculateTotalEarned())
-              .thenReturn(BigDecimal.valueOf(10_000d));
+              .thenReturn(new TotalEarned(BigDecimal.valueOf(10_000d)));
 
-      final BigDecimal total = service.getTotal();
+      final TotalEarned total = service.getTotal();
 
       verify(repo, atLeastOnce()).calculateTotalEarned();
       verifyNoMoreInteractions(repo);
 
       assertNotNull(total, "Total should not be null");
-      assertTrue(total.doubleValue() >= 0d, "Total should not be negative");
+      assertTrue(total.total().doubleValue() >= 0d, "Total should not be negative");
    }
 
    @Test
@@ -49,12 +52,12 @@ public class EarningMetricsServiceTest {
               List.of(new TotalPerMonth(2025, "December", BigDecimal.valueOf(2000d)))
       );
 
-      final var totalPerMonthList = service.getTotalPerMonth();
+      final EarningsByMonthResponse totalPerMonthResponse = service.getTotalPerMonth();
 
       verify(repo, atLeastOnce()).calculateTotalPerMonth();
       verifyNoMoreInteractions(repo);
 
-      assertNotNull(totalPerMonthList, "List should not be null.");
+      assertNotNull(totalPerMonthResponse, "Response should not be null.");
    }
 
    @Test
@@ -64,11 +67,11 @@ public class EarningMetricsServiceTest {
               List.of(new TotalPerMembershipTypeDto("MONTHLY", BigDecimal.valueOf(9_000d)))
       );
 
-      final List<TotalPerMembershipTypeDto> membershipTypeList = service.getTotalPerMembershipType();
+      final EarningsByMembershipTypeResponse membershipTypeResponse = service.getTotalPerMembershipType();
 
       verify(repo, atLeastOnce()).calculateTotalPerMembership();
       verifyNoMoreInteractions(repo);
 
-      assertNotNull(membershipTypeList, "List should not be null.");
+      assertNotNull(membershipTypeResponse, "Response should not be null.");
    }
 }

--- a/src/test/java/com/jame/dev/gymApp/metrics/service/SubscriptionMetricsServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/metrics/service/SubscriptionMetricsServiceTest.java
@@ -3,6 +3,9 @@ package com.jame.dev.gymApp.metrics.service;
 
 import com.jame.dev.gymApp.features.metrics.domain.repository.SubscriptionMetricsRepository;
 import com.jame.dev.gymApp.features.metrics.application.service.SubscriptionMetricsApplicationService;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMembershipResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMonthResponse;
+import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMonthDto;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +21,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,14 +36,14 @@ public class SubscriptionMetricsServiceTest {
    @Test
    @DisplayName("Should return the count of all active and unfinished subscriptions")
    void allSubs() {
-      when(repo.countDistinctByActiveTrueAndFinishedFalse()).thenReturn(2L);
+      when(repo.countAllSubscriptionDistinct()).thenReturn(new TotalSubscriptions(2L));
 
-      final long count = service.getTotalSubscriptions();
+      final TotalSubscriptions result = service.getTotalSubscriptions();
 
-      verify(repo, times(1)).countDistinctByActiveTrueAndFinishedFalse();
+      verify(repo, times(1)).countAllSubscriptionDistinct();
       verifyNoMoreInteractions(repo);
 
-      assertTrue(count >= 0, "Should return 0 or any long value greater then 0.");
+      assertNotNull(result, "Result should not be null.");
    }
 
    @Captor
@@ -52,9 +54,9 @@ public class SubscriptionMetricsServiceTest {
    void subsBeforeDate() {
       final LocalDate date = LocalDate.of(2025, 12, 13);
       when(repo.countByStartDateBefore(any(LocalDate.class)))
-              .thenReturn(3L);
+              .thenReturn(new TotalSubscriptions(3L));
 
-      final long count = service.getSubscriptionsBefore(date);
+      final TotalSubscriptions result = service.getSubscriptionsBefore(date);
 
       verify(repo, times(1)).countByStartDateBefore(dateCaptor.capture());
       verifyNoMoreInteractions(repo);
@@ -62,7 +64,7 @@ public class SubscriptionMetricsServiceTest {
       final LocalDate dateValue = dateCaptor.getValue();
 
       assertNotNull(dateValue, "Date should not be null.");
-      assertTrue(count >= 0, "Should return 0 or any long value greater then 0.");
+      assertNotNull(result, "Result should not be null.");
    }
 
    @Test
@@ -71,12 +73,12 @@ public class SubscriptionMetricsServiceTest {
       when(repo.countSubsByMembership())
               .thenReturn(List.of(new SubsPerMembership("MONTHLY", 2L)));
 
-      final List<SubsPerMembership> membershipCountList = service.getSubscriptionsPerMembership();
+      final SubscriptionsPerMembershipResponse membershipCountList = service.getSubscriptionsPerMembership();
 
       verify(repo, times(1)).countSubsByMembership();
       verifyNoMoreInteractions(repo);
 
-      assertNotNull(membershipCountList, "List should not be null.");
+      assertNotNull(membershipCountList, "Response should not be null.");
    }
 
    @Test
@@ -85,11 +87,11 @@ public class SubscriptionMetricsServiceTest {
       when(repo.countSubsByMonth())
               .thenReturn(List.of(new SubsPerMonthDto("December", 2L)));
 
-      final List<SubsPerMonthDto> monthDtoList = service.getSubscriptionsPerMonth();
+      final SubscriptionsPerMonthResponse monthDtoList = service.getSubscriptionsPerMonth();
 
       verify(repo, times(1)).countSubsByMonth();
       verifyNoMoreInteractions(repo);
 
-      assertNotNull(monthDtoList, "List should not be null.");
+      assertNotNull(monthDtoList, "Response should not be null.");
    }
 }


### PR DESCRIPTION
# Description

This pull request resolves Redis cache deserialization issues affecting most metrics endpoints. Instead of caching raw `List<>` responses, each metric endpoint now returns a dedicated response record containing a `content` property, providing a consistent response contract and allowing the `redisCacheManager` to serialize and deserialize cached responses correctly.

# Main Changes

- Fixed Redis cache deserialization failures caused by caching raw `List<>` responses.
- Introduced dedicated response wrapper records for collection-based metrics, exposing a standardized `content` property.
- Updated all metrics service contracts to return response wrapper records instead of raw collections.
- Refactored application services to build and return the new response objects while preserving existing business logic.
- Updated all metrics REST controllers to expose the new response types.
- Adjusted `@Cacheable` conditions to validate `result.content.isEmpty()` instead of checking the collection directly.
- Standardized the API response format across:
  - Earnings metrics.
  - Subscription metrics.
  - Payment evolution metrics.
  - Membership and period ranking metrics.
- Updated controller and service unit tests to validate the new response structure and JSON schema.
- Added cache eviction for customer downing evolution metrics after customer and user deletion operations to prevent stale cached data.

# Minimal Changes

- Simplified imports by removing direct `List` return types where no longer necessary.
- Replaced wildcard collection assertions in controller tests with explicit `$.content` JSON path validations.
- Improved naming consistency by introducing dedicated response records for every collection-based endpoint.
- Updated service interfaces to better reflect the HTTP response model.
- Minor refactoring and formatting improvements across metrics services and controllers.

# Notes

- The response payload for multiple metrics endpoints is no longer a raw JSON array. Consumers should now read data from the `content` property.
- This change improves compatibility with Redis serialization while establishing a consistent API contract for future metrics endpoints.
- Existing frontend consumers will need to be updated to read `response.content` instead of assuming the root element is an array.
- The response wrapper approach provides flexibility for future additions such as pagination, metadata, timestamps, or summary information without introducing breaking API changes.