### PR TITLE
Update User credentials.

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/user/api/UserAdministrationController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/api/UserAdministrationController.java
@@ -3,6 +3,7 @@ package com.jame.dev.gymApp.features.user.api;
 import com.jame.dev.gymApp.application.dto.PageDto;
 import com.jame.dev.gymApp.features.auth.infrastructure.annotation.PublishVerifyAndNotifyUser;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
+import com.jame.dev.gymApp.features.user.api.request.UserUpdateRequest;
 import com.jame.dev.gymApp.features.user.api.response.UserMinimalInfoResponse;
 import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 import com.jame.dev.gymApp.features.user.application.usecases.mutation.*;
@@ -90,7 +91,7 @@ public class UserAdministrationController {
       @Minimum final long id,
       @RequestBody
       @Valid
-      @NotNullObject final UserRequest userRequest) {
+      @NotNullObject final UserUpdateRequest userRequest) {
       return ResponseEntity.ok(updateUserUseCase.update(id, userRequest));
    }
 

--- a/src/main/java/com/jame/dev/gymApp/features/user/api/request/UserUpdateRequest.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/api/request/UserUpdateRequest.java
@@ -1,26 +1,19 @@
 package com.jame.dev.gymApp.features.user.api.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
 import com.jame.dev.gymApp.features.user.domain.model.Role;
 import com.jame.dev.gymApp.infrastructure.annotation.EmailValid;
-import com.jame.dev.gymApp.infrastructure.annotation.NotNullObject;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 
 @Builder
-public record UserRequest(
+public record UserUpdateRequest(
    @JsonProperty("name")
-   @NotEmpty(message = "Roles shouldn't be empty")
-   String name,
+   @NotEmpty(message = "Name shouldn't be empty") String name,
    @JsonProperty("email") @EmailValid String email,
-   @JsonProperty("password") @Nullable String password,
-   @JsonProperty("authProvider") @NotNullObject AuthProvider authProvider,
    @JsonProperty("roles")
-   @NotNullObject
    @NotEmpty(message = "Roles shouldn't be empty")
    Set<Role> roles
 ) {

--- a/src/main/java/com/jame/dev/gymApp/features/user/application/contract/UserUpdater.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/application/contract/UserUpdater.java
@@ -1,8 +1,10 @@
 package com.jame.dev.gymApp.features.user.application.contract;
 
-import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
-import com.jame.dev.gymApp.application.contract.Updatable;
+import com.jame.dev.gymApp.features.user.api.request.UserUpdateRequest;
+import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
 
-public interface UserUpdater extends Updatable<UserEntity, UserRequest> {
+public interface UserUpdater {
+   void apply(UserEntity userEntity, UserUpdateRequest userUpdateRequest);
+   void apply(UserEntity userEntity, UserRequest request);
 }

--- a/src/main/java/com/jame/dev/gymApp/features/user/application/service/mutation/UpdateUserUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/application/service/mutation/UpdateUserUseCaseService.java
@@ -3,7 +3,7 @@ package com.jame.dev.gymApp.features.user.application.service.mutation;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogAction;
 import com.jame.dev.gymApp.features.audit.domain.model.AuditLogEntityType;
 import com.jame.dev.gymApp.features.audit.infrastructure.annotation.AuditLog;
-import com.jame.dev.gymApp.features.user.api.request.UserRequest;
+import com.jame.dev.gymApp.features.user.api.request.UserUpdateRequest;
 import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 import com.jame.dev.gymApp.features.user.application.contract.UserFactory;
 import com.jame.dev.gymApp.features.user.application.contract.UserUpdater;
@@ -35,9 +35,9 @@ public class UpdateUserUseCaseService implements UpdateUserUseCase {
       entityId = "#id",
       result = "#result"
    )
-   public UserResponse update(long id, UserRequest request) {
+   public UserResponse update(long id, UserUpdateRequest request) {
       final UserEntity userEntity = userQueryRepository.findById(id)
-         .orElseThrow(() -> new UserEntityNotFoundException("UserEntity with id: '%d' Not found ".formatted(id)));
+         .orElseThrow(() -> new UserEntityNotFoundException("User Not found for id: " + id));
       userUpdater.apply(userEntity, request);
       final UserEntity userUpdated = userMutationRepository.save(userEntity);
       return userFactory.createFromEntity(userUpdated);

--- a/src/main/java/com/jame/dev/gymApp/features/user/application/support/updater/UserApplicationUpdater.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/application/support/updater/UserApplicationUpdater.java
@@ -2,6 +2,7 @@ package com.jame.dev.gymApp.features.user.application.support.updater;
 
 import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
+import com.jame.dev.gymApp.features.user.api.request.UserUpdateRequest;
 import com.jame.dev.gymApp.features.user.application.contract.UserUpdater;
 import com.jame.dev.gymApp.features.user.application.support.mapper.RoleMapper;
 import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
@@ -28,5 +29,12 @@ public class UserApplicationUpdater implements UserUpdater {
       userEntity.setPassword(passwordFinal);
       userEntity.setProvider(AuthProvider.LOCAL != dto.authProvider() ? AuthProvider.LOCAL : dto.authProvider());
       userEntity.setRoles(roleMapper.toEntitySet(dto.roles(), roleRepository));
+   }
+
+   @Override
+   public void apply(UserEntity userEntity, UserUpdateRequest userUpdateRequest) {
+      userEntity.setName(userUpdateRequest.name());
+      userEntity.setEmail(userUpdateRequest.email());
+      userEntity.setRoles(roleMapper.toEntitySet(userUpdateRequest.roles(), roleRepository));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/user/application/usecases/mutation/UpdateUserUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/user/application/usecases/mutation/UpdateUserUseCase.java
@@ -1,8 +1,8 @@
 package com.jame.dev.gymApp.features.user.application.usecases.mutation;
 
-import com.jame.dev.gymApp.features.user.api.request.UserRequest;
+import com.jame.dev.gymApp.features.user.api.request.UserUpdateRequest;
 import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 
 public interface UpdateUserUseCase {
-   UserResponse update(final long id, final UserRequest request);
+   UserResponse update(final long id, final UserUpdateRequest request);
 }

--- a/src/test/java/com/jame/dev/gymApp/auth/service/UserDetailsApplicationServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/auth/service/UserDetailsApplicationServiceTest.java
@@ -1,12 +1,12 @@
 package com.jame.dev.gymApp.auth.service;
 
+import com.jame.dev.gymApp.domain.exception.NoActiveException;
 import com.jame.dev.gymApp.features.auth.application.service.UserDetailsApplicationService;
+import com.jame.dev.gymApp.features.user.application.support.mapper.RoleMapper;
+import com.jame.dev.gymApp.features.user.domain.exception.UserEntityNotFoundException;
 import com.jame.dev.gymApp.features.user.domain.model.RoleEntity;
 import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
-import com.jame.dev.gymApp.domain.exception.NoActiveException;
-import com.jame.dev.gymApp.features.user.domain.exception.UserEntityNotFoundException;
-import com.jame.dev.gymApp.features.user.application.support.mapper.RoleMapper;
-import com.jame.dev.gymApp.features.user.application.contract.UserService;
+import com.jame.dev.gymApp.features.user.domain.repository.UserQueryRepository;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.*;
 class UserDetailsApplicationServiceTest {
 
    @Mock
-   UserService userService;
+   UserQueryRepository userQueryRepository;
    @Mock
    RoleMapper roleMapper;
 
@@ -46,7 +46,7 @@ class UserDetailsApplicationServiceTest {
       UserEntity userEntity = mock(UserEntity.class);
       Collection<GrantedAuthority> authorities = Set.of(mock(GrantedAuthority.class));
 
-      given(userService.getUserByEmail(email)).willReturn(Optional.of(userEntity));
+      given(userQueryRepository.findByEmail(email)).willReturn(Optional.of(userEntity));
       given(userEntity.isActive()).willReturn(true);
       given(userEntity.getRoles()).willReturn(Set.of(new RoleEntity()));
       given(roleMapper.entityToGrantedAuthorities(any())).willReturn(authorities);
@@ -58,7 +58,7 @@ class UserDetailsApplicationServiceTest {
       assertNotNull(result);
       assertEquals(email, result.getUsername());
       assertTrue(result.isEnabled());
-      verify(userService).getUserByEmail(email);
+      verify(userQueryRepository).findByEmail(email);
       verify(roleMapper).entityToGrantedAuthorities(any());
    }
 
@@ -66,7 +66,7 @@ class UserDetailsApplicationServiceTest {
    @DisplayName("Should throw UserEntityNotFoundException when user does not exist")
    void loadUserByUsernameShouldThrowExceptionWhenUserNotFound() {
       String email = "nonexistent@test.com";
-      given(userService.getUserByEmail(email)).willReturn(Optional.empty());
+      given(userQueryRepository.findByEmail(email)).willReturn(Optional.empty());
 
       assertThrowsExactly(UserEntityNotFoundException.class, () -> service.loadUserByUsername(email));
 
@@ -79,7 +79,7 @@ class UserDetailsApplicationServiceTest {
       String email = "inactive@test.com";
       UserEntity userEntity = mock(UserEntity.class);
 
-      given(userService.getUserByEmail(email)).willReturn(Optional.of(userEntity));
+      given(userQueryRepository.findByEmail(email)).willReturn(Optional.of(userEntity));
       given(userEntity.isActive()).willReturn(false);
 
       assertThrowsExactly(NoActiveException.class, () -> service.loadUserByUsername(email));

--- a/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionAdministrationControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionAdministrationControllerTest.java
@@ -26,7 +26,6 @@ import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionUn
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import com.jame.dev.gymApp.features.subscription.domain.model.Period;
 import com.jame.dev.gymApp.features.subscription.infrastructure.notification.service.SubscriptionNotificationAppService;
-import com.jame.dev.gymApp.features.subscription.infrastructure.stripe.session.model.CheckoutCompletionMode;
 import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
 import config.TestConfig;

--- a/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionUserControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionUserControllerTest.java
@@ -213,7 +213,7 @@ class SubscriptionUserControllerTest {
       @Test
       @DisplayName("POST[201] Created")
       void create() throws Exception {
-         var checkoutResponse = new SubscriptionCheckoutResponse("session_123", "https://stripe.com/session_123");
+         var checkoutResponse = mock(SubscriptionCheckoutResponse.class);
          given(stripeCheckoutService.createCheckoutSessionFrom(any(SubscriptionRequest.class))).willReturn(checkoutResponse);
          given(subscriptionCreate.create(any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
          mockMvc.perform(post(URI_TEMPLATE)
@@ -247,9 +247,9 @@ class SubscriptionUserControllerTest {
       @Test
       @DisplayName("POST[409]: Conflict: Subscription already exists")
       void alreadyExists() throws Exception {
-         given(stripeCheckoutService.createCheckoutSessionFrom(any(SubscriptionRequest.class))).willReturn(
-            new SubscriptionCheckoutResponse("session_123", "https://stripe.com/session_123")
-         );
+         var response = mock(SubscriptionCheckoutResponse.class);
+         given(stripeCheckoutService.createCheckoutSessionFrom(any(SubscriptionRequest.class)))
+            .willReturn(response);
          given(subscriptionCreate.create(any(SubscriptionRequest.class))).willThrow(AlreadyExistsException.class);
          mockMvc.perform(post(URI_TEMPLATE)
                .contentType(MediaType.APPLICATION_JSON)
@@ -265,9 +265,9 @@ class SubscriptionUserControllerTest {
       @Test
       @DisplayName("POST[409]: Conflict: Subscription is deactivated")
       void subscriptionIsDeactivated() throws Exception {
-         given(stripeCheckoutService.createCheckoutSessionFrom(any(SubscriptionRequest.class))).willReturn(
-            new SubscriptionCheckoutResponse("session_123", "https://stripe.com/session_123")
-         );
+         var response = mock(SubscriptionCheckoutResponse.class);
+         given(stripeCheckoutService.createCheckoutSessionFrom(any(SubscriptionRequest.class)))
+            .willReturn(response);
          given(subscriptionCreate.create(any(SubscriptionRequest.class))).willThrow(NoActiveException.class);
          mockMvc.perform(post(URI_TEMPLATE)
                .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/jame/dev/gymApp/user/controller/UserAdministrationControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/user/controller/UserAdministrationControllerTest.java
@@ -7,6 +7,7 @@ import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException
 import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthorizationFilter;
 import com.jame.dev.gymApp.features.user.api.UserAdministrationController;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
+import com.jame.dev.gymApp.features.user.api.request.UserUpdateRequest;
 import com.jame.dev.gymApp.features.user.api.response.UserMinimalInfoResponse;
 import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 import com.jame.dev.gymApp.features.user.application.usecases.mutation.*;
@@ -305,7 +306,7 @@ class UserAdministrationControllerTest {
          @Test
          @DisplayName("PUT[200] OK: Editing user")
          void putUser() throws Exception {
-            given(updateUserUseCase.update(anyLong(), any(UserRequest.class))).willReturn(userDto);
+            given(updateUserUseCase.update(anyLong(), any(UserUpdateRequest.class))).willReturn(userDto);
 
             mockMvc.perform(put(URI_TEMPLATE + "/1")
                   .accept(MediaType.APPLICATION_JSON)
@@ -314,13 +315,13 @@ class UserAdministrationControllerTest {
                .andExpect(status().isOk())
                .andExpect(jsonPath("$.*").exists());
 
-            then(updateUserUseCase).should(times(1)).update(anyLong(), any(UserRequest.class));
+            then(updateUserUseCase).should(times(1)).update(anyLong(), any(UserUpdateRequest.class));
          }
 
          @Test
          @DisplayName("PUT[404] Not Found")
          void userNotFound() throws Exception {
-            given(updateUserUseCase.update(anyLong(), any(UserRequest.class)))
+            given(updateUserUseCase.update(anyLong(), any(UserUpdateRequest.class)))
                .willThrow(UserNotFoundException.class);
 
             mockMvc.perform(put(URI_TEMPLATE + "/1")
@@ -331,7 +332,7 @@ class UserAdministrationControllerTest {
                .andExpect(jsonPath("$.*").exists())
                .andExpect(jsonPath("$.status").value(404));
 
-            then(updateUserUseCase).should(times(1)).update(anyLong(), any(UserRequest.class));
+            then(updateUserUseCase).should(times(1)).update(anyLong(), any(UserUpdateRequest.class));
          }
 
          @ParameterizedTest

--- a/src/test/java/com/jame/dev/gymApp/user/usecases/mutation/UpdateUserUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/user/usecases/mutation/UpdateUserUseCaseServiceTest.java
@@ -1,7 +1,6 @@
 package com.jame.dev.gymApp.user.usecases.mutation;
 
-import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
-import com.jame.dev.gymApp.features.user.api.request.UserRequest;
+import com.jame.dev.gymApp.features.user.api.request.UserUpdateRequest;
 import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 import com.jame.dev.gymApp.features.user.application.contract.UserFactory;
 import com.jame.dev.gymApp.features.user.application.contract.UserUpdater;
@@ -51,11 +50,9 @@ class UpdateUserUseCaseServiceTest {
     @Captor
     private ArgumentCaptor<UserEntity> userEntityCaptor;
 
-    private final UserRequest request = UserRequest.builder()
+    private final UserUpdateRequest request = UserUpdateRequest.builder()
             .name("John Updated")
             .email("john@mail.com")
-            .password("newsecret")
-            .authProvider(AuthProvider.LOCAL)
             .roles(Set.of(Role.USER))
             .build();
 
@@ -67,7 +64,7 @@ class UpdateUserUseCaseServiceTest {
         var response = mock(UserResponse.class);
 
         given(userQueryRepository.findById(anyLong())).willReturn(Optional.of(entity));
-        willDoNothing().given(userUpdater).apply(any(UserEntity.class), any(UserRequest.class));
+        willDoNothing().given(userUpdater).apply(any(UserEntity.class), any(UserUpdateRequest.class));
         given(userMutationRepository.save(any(UserEntity.class))).willReturn(savedEntity);
         given(userFactory.createFromEntity(any(UserEntity.class))).willReturn(response);
 
@@ -75,7 +72,7 @@ class UpdateUserUseCaseServiceTest {
 
         assertNotNull(result);
         verify(userQueryRepository).findById(anyLong());
-        verify(userUpdater).apply(any(UserEntity.class), any(UserRequest.class));
+        verify(userUpdater).apply(any(UserEntity.class), any(UserUpdateRequest.class));
         verify(userMutationRepository).save(userEntityCaptor.capture());
         verify(userFactory).createFromEntity(any(UserEntity.class));
         assertSame(entity, userEntityCaptor.getValue());


### PR DESCRIPTION
# Description

This pull request refactors the user administration update flow by removing the ability for administrators to modify other users' passwords through the generic update endpoint. User profile updates are now limited to editable profile information, while password management is delegated to the dedicated password update endpoint, reinforcing separation of responsibilities and improving security.

# Main Changes

- Removed password update support from the user administration update endpoint.
- Introduced a dedicated `UserUpdateRequest` DTO containing only editable profile fields (`name`, `email`, and `roles`).
- Updated `UserAdministrationController` to consume the new `UserUpdateRequest` for user updates.
- Refactored `UpdateUserUseCase` and its implementation to operate with the new update request model.
- Extended `UserUpdater` with a dedicated overload to separately handle user creation and user profile updates.
- Updated `UserApplicationUpdater` to prevent password and authentication provider modifications during administrative updates.
- Preserved the original `UserRequest` model for user creation, where password and authentication provider are still required.
- Updated unit and controller tests to validate the new update workflow and request model.

# Minimal Changes

- Improved the user not found exception message for better readability.
- Refined validation annotations for user request DTOs.
- Reorganized imports across affected classes.
- Replaced concrete `SubscriptionCheckoutResponse` instances with mocks in controller tests.
- Removed an unused import from subscription controller tests.
- Performed minor formatting and code cleanup throughout the affected modules.

# Notes

- Password updates are now intentionally isolated behind their dedicated endpoint, preventing administrators from changing credentials through the general user update operation.
- Separating creation and update request models reduces the risk of unintentionally modifying sensitive fields and makes each API contract more explicit.
- This refactoring lays the groundwork for future password-related features, such as current password verification, password history validation, or MFA-protected credential changes, without impacting the general user management flow.