### PR TITLE
Subscription Status

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/domain/model/BaseEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/domain/model/BaseEntity.java
@@ -51,12 +51,17 @@ public abstract class BaseEntity {
    }
 
    @PrePersist
-   public void setCreatedAt() {
+   void setCreatedAt() {
       this.createdAt = Instant.now();
    }
 
+   @PreUpdate
+   void setUpdatedAt() {
+      this.updatedAt = Instant.now();
+   }
+
    @PreRemove
-   public void setDeletedAt() {
+   void setDeletedAt() {
       this.deletedAt = Instant.now();
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/audit/application/support/helper/ChangeModelResolverHelper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/application/support/helper/ChangeModelResolverHelper.java
@@ -46,7 +46,7 @@ public class ChangeModelResolverHelper {
          .price(response.price())
          .membership(response.membership())
          .periods(response.periods())
-         .finished(response.finished())
+         .status(response.status())
          .build();
 
       if (input == null) return Map.of(
@@ -60,7 +60,7 @@ public class ChangeModelResolverHelper {
             .price(null)
             .membership(input.membership())
             .periods(null)
-            .finished(null)
+            .status(null)
             .build(),
          "after", changesAfter
       );

--- a/src/main/java/com/jame/dev/gymApp/features/audit/domain/model/ChangesModelSubscription.java
+++ b/src/main/java/com/jame/dev/gymApp/features/audit/domain/model/ChangesModelSubscription.java
@@ -2,6 +2,7 @@ package com.jame.dev.gymApp.features.audit.domain.model;
 
 import com.jame.dev.gymApp.features.subscription.application.dto.PeriodDtoOutput;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import lombok.Builder;
 import org.jspecify.annotations.Nullable;
 
@@ -15,6 +16,6 @@ public record ChangesModelSubscription(
    @Nullable BigDecimal price,
    Membership membership,
    @Nullable List<PeriodDtoOutput> periods,
-   @Nullable Boolean finished
+   @Nullable SubscriptionStatus status
 ) {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EarningMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/EarningMetricsRepository.java
@@ -17,7 +17,7 @@ public interface EarningMetricsRepository extends MetricsRepository<Subscription
               DISTINCT COALESCE(SUM(mp.price), 0) as total
            FROM subscriptions s
            INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
-           WHERE s.paid = true
+           WHERE s.status = 'PAID'
            """)
    TotalEarned calculateTotalEarned();
 
@@ -30,7 +30,7 @@ public interface EarningMetricsRepository extends MetricsRepository<Subscription
            INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
            INNER JOIN periods p ON p.id = sp.period_id
            INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
-           WHERE s.paid = true
+           WHERE s.status = 'PAID'
            GROUP BY
                EXTRACT(YEAR FROM p.start_period),
                EXTRACT(MONTH FROM p.start_period),
@@ -48,7 +48,7 @@ public interface EarningMetricsRepository extends MetricsRepository<Subscription
            FROM subscriptions s
            INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
            INNER JOIN memberships m ON m.id = mp.membership_id
-           WHERE s.paid = true
+           WHERE s.status = 'PAID'
            GROUP BY m.membership
            ORDER BY m.membership DESC
            """)
@@ -68,7 +68,7 @@ public interface EarningMetricsRepository extends MetricsRepository<Subscription
       INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
       INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
       INNER JOIN periods p ON p.id = sp.period_id
-      WHERE s.paid = true
+      WHERE s.status = 'PAID'
       GROUP BY p.start_period, p.end_period, p.period
       """)
    List<YearPeriodicalEarning> calculatePeriodicalEarnings();

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 public interface SubscriptionMetricsRepository extends
    MetricsRepository<SubscriptionEntity, Long> {
 
-   @NativeQuery("SELECT DISTINCT COUNT(s) AS total FROM subscriptions s WHERE paid = true")
+   @NativeQuery("SELECT DISTINCT COUNT(s) AS total FROM subscriptions s WHERE status = 'PAID'")
    TotalSubscriptions countAllSubscriptionDistinct();
 
    @NativeQuery(
@@ -28,7 +28,7 @@ public interface SubscriptionMetricsRepository extends
       FROM subscriptions s
       INNER JOIN membership_pricing mp ON mp.id = s.pricing_id
       INNER JOIN memberships m ON m.id = mp.membership_id
-      WHERE s.paid = true
+      WHERE s.status = 'PAID'
       GROUP BY m.membership
       """)
    List<MembershipRanking> calculateMembershipRanking();
@@ -50,7 +50,7 @@ public interface SubscriptionMetricsRepository extends
       INNER JOIN memberships m ON m.id = mp.membership_id
       INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
       INNER JOIN periods p ON p.id = sp.period_id
-      WHERE s.paid = true
+      WHERE s.status = 'PAID'
       GROUP BY p.start_period, p.end_period, p.period
       """)
    List<PeriodSubscribersRanking> calculatePeriodWithMostSubscribers();
@@ -61,7 +61,7 @@ public interface SubscriptionMetricsRepository extends
       FROM subscriptions s
       INNER JOIN subscription_periods sp ON sp.subscription_id = s.id
       INNER JOIN periods p ON p.id = sp.period_id
-      WHERE s.paid = true AND p.start_period <= :now
+      WHERE s.status = 'PAID' AND p.start_period <= :now
       """)
    TotalSubscriptions countByStartDateBefore(@Param("now") LocalDate now);
 
@@ -72,7 +72,7 @@ public interface SubscriptionMetricsRepository extends
       FROM subscriptions s
       LEFT JOIN subscription_periods sp ON sp.subscription_id = s.id
       INNER JOIN periods p ON p.id = sp.period_id
-      WHERE s.paid = true
+      WHERE s.status = 'PAID'
       GROUP BY TO_CHAR(p.start_period, 'FMMon')
       ORDER BY MIN(p.start_period)
       """)

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/query/EvolutionMetricsRepositorySqlAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/query/EvolutionMetricsRepositorySqlAdapter.java
@@ -79,7 +79,7 @@ public class EvolutionMetricsRepositorySqlAdapter implements EvolutionMetricsRep
          FROM generate_series(1, 12) AS m(month_number)
          LEFT JOIN subscriptions s
              ON EXTRACT(MONTH FROM s.created_at) = m.month_number
-             AND s.paid = true
+             AND s.status = 'PAID'
              AND EXTRACT(YEAR FROM s.created_at) = :year
          GROUP BY m.month_number
          ORDER BY m.month_number
@@ -105,8 +105,7 @@ public class EvolutionMetricsRepositorySqlAdapter implements EvolutionMetricsRep
          FROM generate_series(1, 12) AS m(month_number)
          LEFT JOIN subscriptions s
              ON EXTRACT(MONTH FROM s.created_at) = m.month_number
-             AND s.paid = true
-             AND (s.finished = true OR s.active = false)
+             AND (s.status = 'FINALIZED' OR s.active = false)
              AND EXTRACT(YEAR FROM s.created_at) = :year
          LEFT JOIN
              subscription_periods sp ON sp.subscription_id = s.id

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/api/response/SubscriptionResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/api/response/SubscriptionResponse.java
@@ -3,6 +3,7 @@ package com.jame.dev.gymApp.features.subscription.api.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jame.dev.gymApp.features.subscription.application.dto.PeriodDtoOutput;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import lombok.Builder;
 
 import java.math.BigDecimal;
@@ -10,12 +11,11 @@ import java.util.List;
 
 @Builder
 public record SubscriptionResponse(
-        @JsonProperty("id") Long id,
-        @JsonProperty("customerEmail") String customerEmail,
-        @JsonProperty("membership") Membership membership,
-        @JsonProperty("price") BigDecimal price,
-        @JsonProperty("periods") List<PeriodDtoOutput> periods,
-        @JsonProperty("finished") boolean finished,
-        @JsonProperty("isPaid") boolean isPaid
-) {
+   @JsonProperty("id") Long id,
+   @JsonProperty("customerEmail") String customerEmail,
+   @JsonProperty("membership") Membership membership,
+   @JsonProperty("price") BigDecimal price,
+   @JsonProperty("periods") List<PeriodDtoOutput> periods,
+   @JsonProperty("status") SubscriptionStatus status
+   ) {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/contract/SubscriptionFactory.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/contract/SubscriptionFactory.java
@@ -7,6 +7,7 @@ import com.jame.dev.gymApp.features.subscription.application.dto.SubscriptionFac
 import com.jame.dev.gymApp.features.subscription.domain.model.PeriodEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 
 import java.util.List;
 
@@ -18,8 +19,7 @@ public interface SubscriptionFactory extends Factory<
          .customer(customerEntity)
          .pricing(pricingEntity)
          .subscriptionPeriods(subscriptionPeriods)
-         .finished(false)
-         .paid(false)
+         .status(SubscriptionStatus.NOT_PAID)
          .build();
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/CompletedCheckoutUseCaseService.java
@@ -9,6 +9,7 @@ import com.jame.dev.gymApp.features.subscription.domain.event.CompletedCheckoutE
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import com.jame.dev.gymApp.features.subscription.domain.repository.PaymentMutationRepository;
 import com.jame.dev.gymApp.features.subscription.domain.repository.PaymentQueryRepository;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
@@ -50,12 +51,11 @@ public class CompletedCheckoutUseCaseService implements CompletedCheckoutUseCase
 
       final PaymentEntity paymentSaved = paymentMutationRepository.save(paymentEntity);
       final SubscriptionEntity subscription = paymentSaved.getSubscription();
-      subscription.setPaid(true);
+      subscription.setStatus(SubscriptionStatus.PAID);
       subscriptionMutationRepository.save(subscription);
 
       log.info("Checkout completed: session={}, subscription={}, customer={}",
          event.stripeSessionId(), subscription.getId(), event.customerEmail());
-      log.info("Subscription is Paid: {}", subscription.isPaid());
       log.info("Payment status: {}", paymentSaved.getStatus());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/service/mutation/FinalizeSubscriptionUseCaseService.java
@@ -11,6 +11,7 @@ import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.F
 import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
 import com.jame.dev.gymApp.features.subscription.domain.model.PaymentStatus;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
 import com.jame.dev.gymApp.features.subscription.infrastructure.annotations.CacheEvictSubscriptions;
@@ -64,8 +65,7 @@ public class FinalizeSubscriptionUseCaseService implements FinalizeSubscriptionU
             p.setUpdatedAt(updatedAt);
          });
 
-      subscription.setFinished(true);
-      subscription.setUpdatedAt(updatedAt);
+      subscription.setStatus(SubscriptionStatus.FINALIZED);
       return subscriptionFactory.createFromEntity(subscriptionMutationRepository.save(subscription));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/factory/SubscriptionApplicationFactory.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/factory/SubscriptionApplicationFactory.java
@@ -1,18 +1,17 @@
 package com.jame.dev.gymApp.features.subscription.application.support.factory;
 
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.application.support.factories.PageDtoFactory;
+import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
+import com.jame.dev.gymApp.features.subscription.application.dto.SubscriptionFactoryDtoInput;
+import com.jame.dev.gymApp.features.subscription.application.support.mapper.SubscriptionMapper;
 import com.jame.dev.gymApp.features.subscription.domain.model.PeriodEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
-import com.jame.dev.gymApp.application.support.factories.PageDtoFactory;
-import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionFactory;
-import com.jame.dev.gymApp.features.subscription.application.support.mapper.SubscriptionMapper;
-import com.jame.dev.gymApp.features.subscription.application.dto.SubscriptionFactoryDtoInput;
-import com.jame.dev.gymApp.application.dto.PageDto;
-import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
 import java.util.List;
 
 @Component
@@ -23,7 +22,7 @@ public class SubscriptionApplicationFactory implements SubscriptionFactory {
    private final PageDtoFactory<SubscriptionEntity, SubscriptionResponse> pageSubscriptionFactory;
 
    @Override
-   public PageDto<SubscriptionResponse> createPageFrom(final Page<SubscriptionEntity> page){
+   public PageDto<SubscriptionResponse> createPageFrom(final Page<SubscriptionEntity> page) {
       return pageSubscriptionFactory.createPageDtoFrom(page);
    }
 
@@ -35,10 +34,6 @@ public class SubscriptionApplicationFactory implements SubscriptionFactory {
    @Override
    public SubscriptionEntity createFromInput(SubscriptionFactoryDtoInput input) {
       final List<PeriodEntity> periods = periodFactory.createPeriodsFrom(input.pricing(), input.startDate());
-      final SubscriptionEntity subscriptionEntity =  subscriptionMapper.toEntity(
-              input.customer(), input.pricing(), periods
-      );
-      subscriptionEntity.setCreatedAt(Instant.now());
-      return subscriptionEntity;
+      return subscriptionMapper.toEntity(input.customer(), input.pricing(), periods);
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/mapper/SubscriptionMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/mapper/SubscriptionMapper.java
@@ -4,9 +4,7 @@ import com.jame.dev.gymApp.application.support.mapper.BaseMapper;
 import com.jame.dev.gymApp.features.customer.application.support.mapper.CustomerMapper;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
-import com.jame.dev.gymApp.features.subscription.domain.model.PeriodEntity;
-import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
-import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.*;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -19,12 +17,9 @@ import java.util.List;
 public interface SubscriptionMapper extends BaseMapper<SubscriptionEntity, SubscriptionResponse> {
 
    @Override
-   @Mapping(source = "id", target = "id")
    @Mapping(source = "customer.user.email", target = "customerEmail")
    @Mapping(source = "pricing.memberShipEntity.membership", target = "membership")
    @Mapping(source = "pricing.price", target = "price")
-   @Mapping(target = "periods", source = "subscriptionPeriods")
-   @Mapping(target = "isPaid", source = "paid")
    SubscriptionResponse toDto(SubscriptionEntity entity);
 
    default SubscriptionEntity toEntity(
@@ -35,8 +30,7 @@ public interface SubscriptionMapper extends BaseMapper<SubscriptionEntity, Subsc
          .customer(customerEntity)
          .pricing(pricingEntity)
          .subscriptionPeriods(periods)
-         .finished(false)
-         .paid(false)
+         .status(SubscriptionStatus.NOT_PAID)
          .build();
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/updater/SubscriptionApplicationUpdater.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/updater/SubscriptionApplicationUpdater.java
@@ -1,14 +1,14 @@
 package com.jame.dev.gymApp.features.subscription.application.support.updater;
 
+import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionUpdater;
+import com.jame.dev.gymApp.features.subscription.application.support.factory.PeriodFactory;
 import com.jame.dev.gymApp.features.subscription.domain.model.PeriodEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.PricingEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
-import com.jame.dev.gymApp.features.subscription.application.support.factory.PeriodFactory;
-import com.jame.dev.gymApp.features.subscription.application.contract.SubscriptionUpdater;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -29,8 +29,7 @@ public class SubscriptionApplicationUpdater implements SubscriptionUpdater {
 
       subscription.setPricing(newPricing);
       subscription.setSubscriptionPeriods(periods);
-      subscription.setFinished(false);
-      subscription.setUpdatedAt(Instant.now());
+      subscription.setStatus(subscription.getStatus());
    }
 
    @Override
@@ -44,8 +43,6 @@ public class SubscriptionApplicationUpdater implements SubscriptionUpdater {
 
       subscriptionEntity.setPricing(pricing);
       subscriptionEntity.setSubscriptionPeriods(periods);
-      subscriptionEntity.setFinished(false);
-      subscriptionEntity.setPaid(false);
-      subscriptionEntity.setUpdatedAt(Instant.now());
+      subscriptionEntity.setStatus(SubscriptionStatus.NOT_PAID);
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/validator/SubscriptionValidator.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/application/support/validator/SubscriptionValidator.java
@@ -7,6 +7,7 @@ import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNo
 import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionUnfinishedException;
 import com.jame.dev.gymApp.features.customer.domain.model.CustomerEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
 import com.jame.dev.gymApp.features.subscription.infrastructure.persistence.SubscriptionRepository;
@@ -31,7 +32,7 @@ public class SubscriptionValidator {
       final SubscriptionEntity subscription = subscriptionRepository.findById(id)
          .orElseThrow(() -> new SubscriptionNotFoundException("Subscription Not Found."));
 
-      if (!subscription.isFinished()) {
+      if (subscription.getStatus() != SubscriptionStatus.FINALIZED) {
          throw new SubscriptionUnfinishedException("Subscription unfinished, cannot renew yet.");
       }
 
@@ -50,7 +51,7 @@ public class SubscriptionValidator {
    }
 
    public boolean canRenewSubscription(final SubscriptionEntity subscription) {
-      if (subscription.isFinished()) return true;
+      if (subscription.getStatus() == SubscriptionStatus.FINALIZED) return true;
       final var currentPeriod = subscription.getSubscriptionPeriods().getLast();
       final var subscriptionFinishDate = currentPeriod.getEndPeriod();
       final LocalDate now = LocalDate.now();

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/SubscriptionEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/SubscriptionEntity.java
@@ -63,15 +63,13 @@ public class SubscriptionEntity extends BaseEntity {
    @Builder.Default
    private List<PaymentEntity> payments = new LinkedList<>();
 
-   @Column(name = "finished", nullable = false)
-   private boolean finished;
+   @Column(name = "status", nullable = false, length = 12)
+   @Enumerated(EnumType.STRING)
+   private SubscriptionStatus status;
 
-   @Column(name = "paid", nullable = false)
-   private boolean paid = false;
-
-   @PostPersist
-   private void setStatus() {
-      this.finished = false;
+   @PreRemove
+   private void setFinalized(){
+      this.status = SubscriptionStatus.DROPPED;
    }
 
    @Override
@@ -82,15 +80,13 @@ public class SubscriptionEntity extends BaseEntity {
              customerId=%d,
              pricingId=%d,
              active=%b,
-             finished=%b
-             isPaid=%b
+             status=%s
          }""".formatted(
          super.getId(),
          customer.getId(),
          pricing.getId(),
          active,
-         finished,
-         paid
+         status.name()
       );
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/SubscriptionStatus.java
+++ b/src/main/java/com/jame/dev/gymApp/features/subscription/domain/model/SubscriptionStatus.java
@@ -1,0 +1,5 @@
+package com.jame.dev.gymApp.features.subscription.domain.model;
+
+public enum SubscriptionStatus {
+   FINALIZED, NOT_PAID, PAID, DROPPED
+}

--- a/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
+++ b/src/main/java/com/jame/dev/gymApp/infrastructure/config/app/InitConfig.java
@@ -179,8 +179,7 @@ public class InitConfig {
          .customer(customer)
          .pricing(pricingMap.get(memberships[randomIdx]))
          .subscriptionPeriods(List.of(new PeriodEntity(periods[randomIdx], LocalDate.now())))
-         .finished(random.nextBoolean())
-         .paid(true)
+         .status(SubscriptionStatus.PAID)
          .build();
    }
 

--- a/src/test/java/com/jame/dev/gymApp/mapper/SubscriptionMapperTest.java
+++ b/src/test/java/com/jame/dev/gymApp/mapper/SubscriptionMapperTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SubscriptionMapperTest {
    private final PeriodMapper periodMapper = new PeriodMapperImpl();
    private final SubscriptionMapper subscriptionMapper =
-           new SubscriptionMapperImpl(periodMapper);
+           new SubscriptionMapperImpl();
    private CustomerEntity customer;
    private PricingEntity pricing;
    private SubscriptionEntity subs;
@@ -41,7 +41,7 @@ public class SubscriptionMapperTest {
               .customer(customer)
               .pricing(pricing)
               .subscriptionPeriods(List.of(new PeriodEntity()))
-              .finished(false)
+              .status(SubscriptionStatus.PAID)
               .build();
    }
 
@@ -55,7 +55,7 @@ public class SubscriptionMapperTest {
               () -> assertNotNull(dto, "Should not be null."),
               () -> assertEquals(price, dto.price(), "Should be the same."),
               () -> assertEquals(membership, dto.membership(), "Should be the same."),
-              () -> assertFalse(dto.finished(), "Should not be finished."));
+              () -> assertEquals(SubscriptionStatus.PAID, dto.status(), "Status should be equals."));
    }
 
    @Test
@@ -69,6 +69,6 @@ public class SubscriptionMapperTest {
               () -> assertEquals(customer, subs.getCustomer(), "Should be the same."),
               () -> assertEquals(pricing, subs.getPricing(), "Should be the same."),
               () -> assertEquals(periods, subs.getSubscriptionPeriods(), "Should be the same."),
-              () -> assertFalse(subs.isFinished(), "Should be finished."));
+              () -> assertEquals(SubscriptionStatus.PAID, subs.getStatus(), "Status should be equals."));
    }
 }

--- a/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionAdministrationControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionAdministrationControllerTest.java
@@ -10,12 +10,7 @@ import com.jame.dev.gymApp.features.subscription.api.SubscriptionAdministrationC
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.subscription.application.dto.PeriodDtoOutput;
-import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CompletedCheckoutUseCase;
-import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreateSubscriptionUseCase;
-import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.FinalizeSubscriptionUseCase;
-import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.RenewSubscriptionUseCase;
-import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.SoftDeleteSubscriptionByIdUseCase;
-import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.UpdateSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.*;
 import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByIdSubscriptionUseCase;
 import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetPageSubscriptionUseCase;
 import com.jame.dev.gymApp.features.subscription.domain.event.CompletedCheckoutEvent;
@@ -25,6 +20,7 @@ import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNo
 import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionUnfinishedException;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import com.jame.dev.gymApp.features.subscription.domain.model.Period;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import com.jame.dev.gymApp.features.subscription.infrastructure.notification.service.SubscriptionNotificationAppService;
 import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
@@ -125,6 +121,10 @@ class SubscriptionAdministrationControllerTest {
    @MockitoBean
    private CompletedCheckoutUseCase completedCheckoutUseCase;
 
+   @MockitoBean
+   private CreatePaymentUseCase createPaymentUseCase;
+
+
    private final String URI_TEMPLATE = "/app/v1/administration/subs";
    private final String customerEmail = "user@mail.com";
 
@@ -132,8 +132,7 @@ class SubscriptionAdministrationControllerTest {
       1L, customerEmail,
       Membership.ANNUAL, BigDecimal.valueOf(3000d),
       List.of(new PeriodDtoOutput(Period.ANNUAL, LocalDate.now(), LocalDate.now().plusYears(1))),
-      false,
-      false
+      SubscriptionStatus.PAID
    );
 
    @Nested
@@ -209,8 +208,8 @@ class SubscriptionAdministrationControllerTest {
       @Test
       @DisplayName("POST[201] Created")
       void postSubscription() throws Exception {
-         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
          doNothing().when(completedCheckoutUseCase).execute(any(CompletedCheckoutEvent.class));
+         given(subscriptionCreate.create(any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
          given(subscriptionGetById.getById(anyLong())).willReturn(subscriptionResponse);
          mockMvc.perform(post(URI_TEMPLATE)
                .contentType(MediaType.APPLICATION_JSON)
@@ -220,6 +219,7 @@ class SubscriptionAdministrationControllerTest {
             .andExpect(jsonPath("$.id").isNotEmpty());
          verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
          verify(completedCheckoutUseCase, times(1)).execute(any(CompletedCheckoutEvent.class));
+         verify(createPaymentUseCase, times(1)).create(any());
          verify(subscriptionGetById, times(1)).getById(anyLong());
       }
 
@@ -549,8 +549,7 @@ class SubscriptionAdministrationControllerTest {
             subscriptionResponse.membership(),
             subscriptionResponse.price(),
             subscriptionResponse.periods(),
-            true,
-            false
+            SubscriptionStatus.FINALIZED
          );
          given(subscriptionFinalize.finalize(anyLong())).willReturn(finalized);
          mockMvc.perform(patch(URI_TEMPLATE + '/' + 1L)

--- a/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionUserControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/controller/SubscriptionUserControllerTest.java
@@ -1,24 +1,32 @@
 package com.jame.dev.gymApp.subscription.controller;
 
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.domain.exception.EntityNotFoundException;
 import com.jame.dev.gymApp.domain.exception.MissMatchException;
 import com.jame.dev.gymApp.domain.exception.NoActiveException;
 import com.jame.dev.gymApp.features.auth.domain.exception.AlreadyExistsException;
 import com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthorizationFilter;
 import com.jame.dev.gymApp.features.subscription.api.SubscriptionUserController;
 import com.jame.dev.gymApp.features.subscription.api.request.SubscriptionRequest;
+import com.jame.dev.gymApp.features.subscription.api.response.RetryResponse;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionCheckoutResponse;
 import com.jame.dev.gymApp.features.subscription.api.response.SubscriptionResponse;
 import com.jame.dev.gymApp.features.subscription.application.contract.StripeCheckoutService;
 import com.jame.dev.gymApp.features.subscription.application.dto.PeriodDtoOutput;
+import com.jame.dev.gymApp.features.subscription.application.support.handler.RetrySubscriptionPaymentHandler;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreatePaymentUseCase;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.CreateSubscriptionUseCase;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.FinalizeSubscriptionUseCase;
 import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.RenewSubscriptionUseCase;
+import com.jame.dev.gymApp.features.subscription.application.usecases.mutation.SoftDeleteSubscriptionByIdUseCase;
 import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetAllSubscriptionsByCustomerEmailUseCase;
 import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByEmailSubscriptionUseCase;
 import com.jame.dev.gymApp.features.subscription.application.usecases.query.GetByIdSubscriptionUseCase;
 import com.jame.dev.gymApp.features.subscription.domain.exception.*;
 import com.jame.dev.gymApp.features.subscription.domain.model.Membership;
 import com.jame.dev.gymApp.features.subscription.domain.model.Period;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
+import com.jame.dev.gymApp.infrastructure.security.principal.IdentityExtractorService;
 import com.jame.dev.gymApp.presentation.exception.ApiErrorResponseFactory;
 import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
 import config.TestConfig;
@@ -40,6 +48,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -102,6 +111,18 @@ class SubscriptionUserControllerTest {
    @MockitoBean
    private StripeCheckoutService stripeCheckoutService;
 
+   @MockitoBean
+   private SoftDeleteSubscriptionByIdUseCase deleteById;
+
+   @MockitoBean
+   private IdentityExtractorService extractorService;
+
+   @MockitoBean
+   private CreatePaymentUseCase createPaymentUseCase;
+
+   @MockitoBean
+   private RetrySubscriptionPaymentHandler retrySubscriptionPaymentHandler;
+
    private final String URI_TEMPLATE = "/app/v1/subscriptions";
    private final String customerEmail = "user@mail.com";
 
@@ -109,8 +130,7 @@ class SubscriptionUserControllerTest {
       1L, customerEmail,
       Membership.ANNUAL, BigDecimal.valueOf(3000d),
       List.of(new PeriodDtoOutput(Period.ANNUAL, LocalDate.now(), LocalDate.now().plusYears(1))),
-      false,
-      false
+      SubscriptionStatus.PAID
    );
 
    @Nested
@@ -214,6 +234,10 @@ class SubscriptionUserControllerTest {
       @DisplayName("POST[201] Created")
       void create() throws Exception {
          var checkoutResponse = mock(SubscriptionCheckoutResponse.class);
+         given(checkoutResponse.sessionUrl()).willReturn("https://stripe.com/session_123");
+         given(checkoutResponse.sessionId()).willReturn("session_123");
+         given(checkoutResponse.paymentIndent()).willReturn("pi_123");
+         given(checkoutResponse.paymentSubscription()).willReturn("sub_123");
          given(stripeCheckoutService.createCheckoutSessionFrom(any(SubscriptionRequest.class))).willReturn(checkoutResponse);
          given(subscriptionCreate.create(any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
          mockMvc.perform(post(URI_TEMPLATE)
@@ -224,9 +248,10 @@ class SubscriptionUserControllerTest {
             .andExpect(jsonPath("$.checkout").exists())
             .andExpect(jsonPath("$.checkout.sessionUrl").value("https://stripe.com/session_123"))
             .andExpect(jsonPath("$.subscription").exists())
-            .andExpect(jsonPath("$.subscription.id").isNotEmpty());
+             .andExpect(jsonPath("$.subscription.id").isNotEmpty());
          verify(stripeCheckoutService, times(1)).createCheckoutSessionFrom(any(SubscriptionRequest.class));
          verify(subscriptionCreate, times(1)).create(any(SubscriptionRequest.class));
+         verify(createPaymentUseCase, times(1)).create(any());
       }
 
       @Test
@@ -344,6 +369,12 @@ class SubscriptionUserControllerTest {
       @Test
       @DisplayName("PUT[200] Ok: Renew Subscription /subscriptions/{id}")
       void renew() throws Exception {
+         var checkoutResponse = mock(SubscriptionCheckoutResponse.class);
+         given(checkoutResponse.sessionUrl()).willReturn("https://stripe.com/renew_123");
+         given(checkoutResponse.sessionId()).willReturn("session_renew_123");
+         given(checkoutResponse.paymentIndent()).willReturn("pi_renew_123");
+         given(checkoutResponse.paymentSubscription()).willReturn("sub_renew_123");
+         given(stripeCheckoutService.createCheckoutSessionFrom(any(SubscriptionRequest.class))).willReturn(checkoutResponse);
          given(subscriptionRenew.renew(anyLong(), any(SubscriptionRequest.class))).willReturn(subscriptionResponse);
          mockMvc.perform(put(URI_TEMPLATE + '/' + 1L)
                .accept(MediaType.APPLICATION_JSON)
@@ -351,7 +382,9 @@ class SubscriptionUserControllerTest {
                .content(payload))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.*").exists());
+         verify(stripeCheckoutService, times(1)).createCheckoutSessionFrom(any(SubscriptionRequest.class));
          verify(subscriptionRenew, times(1)).renew(anyLong(), any(SubscriptionRequest.class));
+         verify(createPaymentUseCase, times(1)).create(any());
       }
 
       @Test
@@ -454,8 +487,7 @@ class SubscriptionUserControllerTest {
             subscriptionResponse.membership(),
             subscriptionResponse.price(),
             subscriptionResponse.periods(),
-            true,
-            false
+            SubscriptionStatus.FINALIZED
          );
          given(subscriptionFinalize.finalize(anyLong())).willReturn(finalized);
          mockMvc.perform(patch(URI_TEMPLATE + '/' + 1L)
@@ -492,6 +524,109 @@ class SubscriptionUserControllerTest {
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.code").value(expectedCode));
          verifyNoInteractions(subscriptionFinalize);
+      }
+   }
+
+   @Nested
+   @DisplayName("POST Retry Subscription.")
+   class SubscriptionUserControllerPostRetryTests {
+
+      @Test
+      @DisplayName("POST[200] OK: retry subscription payment")
+      void retrySuccessfully() throws Exception {
+         given(extractorService.extract(any())).willReturn(customerEmail);
+         given(retrySubscriptionPaymentHandler.handleSubscriptionPaymentRetry(customerEmail))
+            .willReturn(ResponseEntity.ok(new RetryResponse("https://stripe.com/retry_123")));
+         mockMvc.perform(post(URI_TEMPLATE + "/retry")
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.sessionUrl").value("https://stripe.com/retry_123"));
+         verify(extractorService, times(1)).extract(any());
+         verify(retrySubscriptionPaymentHandler, times(1)).handleSubscriptionPaymentRetry(customerEmail);
+      }
+
+      @Test
+      @DisplayName("POST[404] Not Found: retry - payment not found")
+      void retryNotFound() throws Exception {
+         given(extractorService.extract(any())).willReturn(customerEmail);
+         given(retrySubscriptionPaymentHandler.handleSubscriptionPaymentRetry(customerEmail))
+            .willThrow(EntityNotFoundException.class);
+         mockMvc.perform(post(URI_TEMPLATE + "/retry")
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists());
+         verify(extractorService, times(1)).extract(any());
+         verify(retrySubscriptionPaymentHandler, times(1)).handleSubscriptionPaymentRetry(customerEmail);
+      }
+   }
+
+   @Nested
+   @DisplayName("GET Current Subscriptions.")
+   class SubscriptionUserControllerGetCurrentTests {
+
+      @Test
+      @DisplayName("GET[200] OK: get current subscriptions /subscriptions/current")
+      void getAllByCustomerEmail() throws Exception {
+         PageDto<SubscriptionResponse> page = mock();
+         given(page.content()).willReturn(List.of(subscriptionResponse));
+         given(page.totalElements()).willReturn(1L);
+         given(extractorService.extract(any())).willReturn(customerEmail);
+         given(subscriptionGetAllByCustomerEmail.getAllByCustomerEmail(eq(customerEmail), any()))
+            .willReturn(page);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + "/current")
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").exists())
+            .andExpect(jsonPath("$.content[0].id").isNotEmpty());
+         verify(extractorService, times(1)).extract(any());
+         verify(subscriptionGetAllByCustomerEmail, times(1)).getAllByCustomerEmail(eq(customerEmail), any());
+      }
+
+      @Test
+      @DisplayName("GET[200] OK: get current subscriptions - empty page")
+      void getAllByCustomerEmailEmpty() throws Exception {
+         PageDto<SubscriptionResponse> page = mock();
+         given(page.content()).willReturn(List.of());
+         given(page.totalElements()).willReturn(0L);
+         given(extractorService.extract(any())).willReturn(customerEmail);
+         given(subscriptionGetAllByCustomerEmail.getAllByCustomerEmail(eq(customerEmail), any()))
+            .willReturn(page);
+         mockMvc.perform(MockMvcRequestBuilders.get(URI_TEMPLATE + "/current")
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content").isEmpty());
+         verify(extractorService, times(1)).extract(any());
+         verify(subscriptionGetAllByCustomerEmail, times(1)).getAllByCustomerEmail(eq(customerEmail), any());
+      }
+   }
+
+   @Nested
+   @DisplayName("DELETE Subscription Resources.")
+   class SubscriptionUserControllerDeleteTests {
+
+      @Test
+      @DisplayName("DELETE[204] No Content: Subscription deleted")
+      void dropSubscription() throws Exception {
+         mockMvc.perform(delete(URI_TEMPLATE + '/' + 1L))
+            .andExpect(status().isNoContent())
+            .andExpect(jsonPath("$.*").doesNotExist());
+         verify(deleteById, times(1)).softDeleteById(anyLong());
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true,
+         textBlock = TestDataSource.ID_RESOURCE_ERRORS,
+         nullValues = "NULL")
+      @DisplayName("DELETE[400] Bad Request: invalid id format")
+      void badRequestInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(delete(URI_TEMPLATE + '/' + value)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+         verifyNoInteractions(deleteById);
       }
    }
 }

--- a/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/FinalizeSubscriptionUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/subscription/usecases/mutation/FinalizeSubscriptionUseCaseServiceTest.java
@@ -5,6 +5,7 @@ import com.jame.dev.gymApp.features.subscription.application.contract.Subscripti
 import com.jame.dev.gymApp.features.subscription.application.service.mutation.FinalizeSubscriptionUseCaseService;
 import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionStatus;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionMutationRepository;
 import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +17,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -57,8 +57,7 @@ class FinalizeSubscriptionUseCaseServiceTest {
         var result = service.finalize(1L);
 
         assertNotNull(result);
-        assertTrue(entity.isFinished());
-        assertNotNull(entity.getUpdatedAt());
+        assertEquals(SubscriptionStatus.FINALIZED, entity.getStatus());
 
         verify(subscriptionQueryRepository).findById(anyLong());
         verify(subscriptionMutationRepository).save(subscriptionCaptor.capture());
@@ -66,8 +65,7 @@ class FinalizeSubscriptionUseCaseServiceTest {
 
         var captured = subscriptionCaptor.getValue();
         assertSame(entity, captured);
-        assertTrue(captured.isFinished());
-        assertNotNull(captured.getUpdatedAt());
+        assertEquals(SubscriptionStatus.FINALIZED, captured.getStatus());
 
         verifyNoMoreInteractions(subscriptionQueryRepository, subscriptionMutationRepository, subscriptionFactory);
     }


### PR DESCRIPTION
# Description

This PR refactors the subscription domain model by replacing the legacy `finished` and `paid` boolean flags with a unified `SubscriptionStatus` enum. The change propagates the new status model across the subscription lifecycle, service layer, repositories, DTOs, metrics, auditing, and tests, providing a more expressive and maintainable representation of subscription states.

# Main Changes

- Introduced the `SubscriptionStatus` enum with explicit lifecycle states (`NOT_PAID`, `PAID`, `FINALIZED`, and `DROPPED`).
- Refactored `SubscriptionEntity` to replace the `finished` and `paid` flags with a single `status` field persisted as a string enum.
- Updated all subscription creation, renewal, checkout completion, finalization, and deletion flows to transition subscriptions through the appropriate status values.
- Modified `SubscriptionResponse` and MapStruct mappings to expose the new `status` field instead of the previous boolean properties.
- Updated audit models and change resolvers to track subscription status changes rather than the removed `finished` flag.
- Refactored repository queries and metrics calculations to filter subscriptions using `SubscriptionStatus` values instead of boolean conditions.
- Updated validation logic to determine subscription eligibility based on status transitions instead of the removed flags.
- Simplified entity timestamp management by leveraging JPA lifecycle callbacks (`@PreUpdate`) instead of manually updating timestamps within services.
- Updated factories, mappers, initial data generation, and application services to initialize and maintain subscription status consistently.
- Updated unit and controller tests to validate the new status-based workflow and reflect the modified subscription contract.

# Minimal Changes

- Improved formatting and import organization across multiple classes.
- Simplified mapper implementations by removing obsolete field mappings.
- Removed redundant manual timestamp assignments now handled by entity lifecycle callbacks.
- Updated entity `toString()` output to display the subscription status.
- Adjusted test assertions and mock data to use `SubscriptionStatus`.
- Minor cleanup of service implementations and test setup.

# Notes

- Replacing multiple boolean flags with a state-based enum provides a more scalable model for future subscription lifecycle states and reduces invalid state combinations.
- Any external integrations or clients consuming the subscription response must be updated to use the new `status` field instead of `finished` and `isPaid`.
- Future enhancements can further encapsulate status transitions inside the domain model or a dedicated state machine to centralize lifecycle rules and prevent invalid transitions.