### PR TITLE
Subscription annual resume query

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/SubscriptionMetricsController.java
@@ -1,10 +1,6 @@
 package com.jame.dev.gymApp.features.metrics.api;
 
-import com.jame.dev.gymApp.features.metrics.api.response.MembershipRankingsResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingsResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMembershipResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMonthResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
+import com.jame.dev.gymApp.features.metrics.api.response.*;
 import com.jame.dev.gymApp.features.metrics.application.contract.SubscriptionMetricsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -50,5 +46,10 @@ public class SubscriptionMetricsController {
    @GetMapping("/months")
    public ResponseEntity<SubscriptionsPerMonthResponse> getSubsPerMonth() {
       return ResponseEntity.ok(service.getSubscriptionsPerMonth());
+   }
+
+   @GetMapping("/resumes")
+   public ResponseEntity<SubscriptionAnnualResumeResponse> getSubsAnnualResume() {
+      return ResponseEntity.ok(service.getAnnualResume());
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriptionAnnualResumeResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/api/response/SubscriptionAnnualResumeResponse.java
@@ -1,0 +1,13 @@
+package com.jame.dev.gymApp.features.metrics.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SubscriptionAnnualResumeResponse(
+   @JsonProperty("subscriptionCount") long subscriptionCount,
+   @JsonProperty("biweeklyTotal") long biweeklyTotal,
+   @JsonProperty("monthlyTotal") long monthlyTotal,
+   @JsonProperty("quarterlyTotal") long quarterlyTotal,
+   @JsonProperty("annualTotal") long annualTotal,
+   @JsonProperty("mostRequestedMembership") String mostRequestedMembership
+   ) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/contract/SubscriptionMetricsService.java
@@ -1,10 +1,6 @@
 package com.jame.dev.gymApp.features.metrics.application.contract;
 
-import com.jame.dev.gymApp.features.metrics.api.response.MembershipRankingsResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.PeriodRankingsResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMembershipResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionsPerMonthResponse;
-import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
+import com.jame.dev.gymApp.features.metrics.api.response.*;
 import lombok.NonNull;
 
 import java.time.LocalDate;
@@ -21,4 +17,6 @@ public interface SubscriptionMetricsService {
    SubscriptionsPerMonthResponse getSubscriptionsPerMonth();
 
    SubscriptionsPerMembershipResponse getSubscriptionsPerMembership();
+
+   SubscriptionAnnualResumeResponse getAnnualResume();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/application/service/SubscriptionMetricsApplicationService.java
@@ -92,4 +92,13 @@ public class SubscriptionMetricsApplicationService implements SubscriptionMetric
    public SubscriptionsPerMembershipResponse getSubscriptionsPerMembership() {
       return new SubscriptionsPerMembershipResponse(repo.countSubsByMembership());
    }
+
+   @Override
+   @Cacheable(
+      value = CacheSubsMetricsValues.SUBSCRIPTION_ANNUAL_RESUME,
+      unless = "#result == null"
+   )
+   public SubscriptionAnnualResumeResponse getAnnualResume() {
+      return repo.calculateAnnualResume();
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/domain/repository/SubscriptionMetricsRepository.java
@@ -1,6 +1,7 @@
 package com.jame.dev.gymApp.features.metrics.domain.repository;
 
 import com.jame.dev.gymApp.features.metrics.api.response.MembershipRanking;
+import com.jame.dev.gymApp.features.metrics.api.response.SubscriptionAnnualResumeResponse;
 import com.jame.dev.gymApp.features.metrics.domain.model.PeriodSubscribersRanking;
 import com.jame.dev.gymApp.features.metrics.api.response.TotalSubscriptions;
 import com.jame.dev.gymApp.features.metrics.domain.model.SubsPerMembership;
@@ -89,4 +90,33 @@ public interface SubscriptionMetricsRepository extends
       ORDER BY m.membership DESC
       """)
    List<SubsPerMembership> countSubsByMembership();
+
+   @NativeQuery("""
+      WITH memberships_count AS (
+        SELECT
+            m.membership,
+            COUNT(*) AS total,
+            COALESCE(SUM(mp.price), 0) AS amount
+        FROM subscriptions s
+        JOIN membership_pricing mp ON mp.id = s.pricing_id
+        JOIN memberships m ON m.id = mp.membership_id
+        WHERE EXTRACT(YEAR FROM s.created_at) <= EXTRACT(YEAR FROM CURRENT_DATE)
+        GROUP BY m.membership
+      )
+      SELECT
+        SUM(total)::bigint AS subscriptionCount,
+        COALESCE(SUM(total) FILTER ( WHERE membership = 'BIWEEKLY')::bigint, 0) AS biweeklyTotal,
+        COALESCE(SUM(total) FILTER ( WHERE membership = 'MONTHLY')::bigint, 0) AS monthlyTotal,
+        COALESCE(SUM(total) FILTER ( WHERE membership = 'QUARTERLY')::bigint, 0) AS quarterlyTotal,
+        COALESCE(SUM(total) FILTER ( WHERE membership = 'ANNUAL'), 0)::bigint AS annualTotal,
+        (
+           SELECT
+               membership
+           FROM memberships_count
+           ORDER BY total DESC, amount DESC
+           LIMIT 1
+        )::varchar(12) AS mostRequestedMembership
+      FROM memberships_count
+      """)
+   SubscriptionAnnualResumeResponse calculateAnnualResume();
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictSubscriptionMetrics.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/annotations/EvictSubscriptionMetrics.java
@@ -17,6 +17,8 @@ import java.lang.annotation.*;
    @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_TOTAL_PER_MONTH, allEntries = true, cacheManager = "redisCacheManager"),
    @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_RANKING, allEntries = true, cacheManager = "redisCacheManager"),
    @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_PERIOD_RANKING, allEntries = true, cacheManager = "redisCacheManager"),
+   @CacheEvict(value = CacheSubsMetricsValues.SUBSCRIPTION_ANNUAL_RESUME, allEntries = true, cacheManager = "redisCacheManager"),
+
 })
 public @interface EvictSubscriptionMetrics {
 }

--- a/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheSubsMetricsValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/metrics/infrastructure/cache/CacheSubsMetricsValues.java
@@ -7,4 +7,5 @@ public class CacheSubsMetricsValues {
    public static final String SUBSCRIPTION_TOTAL_PER_MEMBERSHIP = "subscriptions:metrics:total:memberships";
    public static final String SUBSCRIPTION_RANKING = "subscriptions:metrics:membership:ranking";
    public static final String SUBSCRIPTION_PERIOD_RANKING = "subscriptions:metrics:period:ranking";
+   public static final String SUBSCRIPTION_ANNUAL_RESUME = "subscriptions:metrics:resume";
 }


### PR DESCRIPTION
# Description

This PR introduces a new annual subscription resume metric that provides a consolidated overview of subscription activity for the current year. It exposes a new endpoint capable of returning the total number of subscriptions, a breakdown by membership type, and the most requested membership, while integrating the feature into the existing metrics service and caching infrastructure.

# Main Changes

- Added a new `calculateAnnualResume()` method to `SubscriptionMetricsRepository` using a native SQL query to aggregate annual subscription statistics.
- Introduced the `SubscriptionAnnualResumeResponse` DTO containing:
  - Total subscriptions.
  - Total subscriptions per membership type (Biweekly, Monthly, Quarterly, and Annual).
  - Most requested membership.
- Added a new `/metrics/subscriptions/resumes` endpoint to expose the annual subscription summary.
- Extended `SubscriptionMetricsService` and its implementation with the new `getAnnualResume()` operation.
- Integrated Redis caching for the annual resume metric through a dedicated cache key.
- Updated the subscription metrics cache eviction annotation to invalidate the annual resume cache whenever subscription metrics are refreshed.
- Implemented the repository query using a Common Table Expression (CTE) to efficiently calculate totals and determine the most requested membership, using total revenue as a secondary tie-breaker when subscription counts are equal.

# Minimal Changes

- Simplified imports using wildcard response imports where appropriate.
- Added a new cache constant for the annual subscription resume metric.
- Updated controller and service interfaces to expose the new functionality.
- Minor formatting improvements across metrics-related classes.

# Notes

- The annual resume endpoint provides a lightweight overview intended for dashboards and administrative reporting.
- Since the response is cached, any operation affecting subscription metrics should continue invalidating the corresponding cache to ensure data consistency.
- The repository query can be extended in the future to include additional KPIs such as total revenue, active subscriptions, renewal rate, or year-over-year comparisons without requiring changes to the endpoint contract.