### PR TITLE
Backup sort resolver

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/domain/repository/CustomMongoSpecification.java
+++ b/src/main/java/com/jame/dev/gymApp/domain/repository/CustomMongoSpecification.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.domain.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomMongoSpecification<T> {
+   Page<T> search(final Pageable pageable, final String search);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/backup/application/service/GetBackupPageUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/backup/application/service/GetBackupPageUseCaseService.java
@@ -6,6 +6,7 @@ import com.jame.dev.gymApp.features.backup.application.support.factory.BackupFac
 import com.jame.dev.gymApp.features.backup.application.usecases.GetBackupPageUseCase;
 import com.jame.dev.gymApp.features.backup.domain.repository.BackupQueryRepository;
 import com.jame.dev.gymApp.features.backup.infrastructure.cache.CacheBackupValues;
+import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class GetBackupPageUseCaseService implements GetBackupPageUseCase {
    private final BackupFactory backupFactory;
    private final BackupQueryRepository backupQueryRepository;
+   private final SortPropertyResolver backupSortPropertyResolver;
 
    @Override
    @Cacheable(
@@ -25,6 +27,7 @@ public class GetBackupPageUseCaseService implements GetBackupPageUseCase {
       unless = "#result == null || #result.content.isEmpty()"
    )
    public PageDto<BackupResponse> getBackupPage(final Pageable pageable, final String search) {
-      return backupFactory.createPageFrom(backupQueryRepository.findAll(pageable, search));
+      final Pageable wrapped = backupSortPropertyResolver.resolve(pageable);
+      return backupFactory.createPageFrom(backupQueryRepository.findAll(wrapped, search));
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/backup/infrastructure/custom_impl/BackupRepositoryImpl.java
+++ b/src/main/java/com/jame/dev/gymApp/features/backup/infrastructure/custom_impl/BackupRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.jame.dev.gymApp.features.backup.infrastructure.custom_impl;
+
+import com.jame.dev.gymApp.domain.repository.CustomMongoSpecification;
+import com.jame.dev.gymApp.features.backup.domain.model.BackupDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class BackupRepositoryImpl implements CustomMongoSpecification<BackupDocument> {
+   private final MongoTemplate mongoTemplate;
+
+   @Override
+   public Page<BackupDocument> search(final Pageable pageable, final String search) {
+      final Query query = new Query();
+      query.with(pageable);
+
+      if (search != null && !search.isBlank()) {
+         query.addCriteria(
+            new Criteria()
+               .orOperator(
+                  Criteria.where("backupStatus").regex(search, "i"),
+                  Criteria.where("fileName").regex(search, "i"),
+                  Criteria.where("createdBy").regex(search, "i")
+               )
+         );
+      }
+
+      final List<BackupDocument> content = mongoTemplate.find(query, BackupDocument.class);
+      final long totalElements = mongoTemplate.count(
+         Query.of(query)
+            .skip(-1)
+            .limit(-1),
+         BackupDocument.class
+      );
+      return new PageImpl<>(content, pageable, totalElements);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/backup/infrastructure/sort/BackupSortProperty.java
+++ b/src/main/java/com/jame/dev/gymApp/features/backup/infrastructure/sort/BackupSortProperty.java
@@ -1,0 +1,16 @@
+package com.jame.dev.gymApp.features.backup.infrastructure.sort;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum BackupSortProperty {
+   ID("id", "id"),
+   SIZE("size", "size"),
+   STATUS("status", "backupStatus"),
+   CREATED_AT("instant", "createdAt");
+
+   private final String apiProperty;
+   private final String entityProperty;
+}

--- a/src/main/java/com/jame/dev/gymApp/features/backup/infrastructure/sort/BackupSortPropertyResolver.java
+++ b/src/main/java/com/jame/dev/gymApp/features/backup/infrastructure/sort/BackupSortPropertyResolver.java
@@ -1,0 +1,25 @@
+package com.jame.dev.gymApp.features.backup.infrastructure.sort;
+
+import com.jame.dev.gymApp.infrastructure.sort.SortPropertyResolver;
+import com.jame.dev.gymApp.infrastructure.sort.SortResolver;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component("backupSortPropertyResolver")
+public class BackupSortPropertyResolver implements SortPropertyResolver {
+   private final Map<String, String> properties = EnumSet.allOf(BackupSortProperty.class)
+      .stream()
+      .collect(Collectors.toMap(
+         BackupSortProperty::getApiProperty,
+         BackupSortProperty::getEntityProperty
+      ));
+
+   @Override
+   public Pageable resolve(Pageable pageable) {
+      return SortResolver.resolveSortPropertiesFrom(pageable, properties);
+   }
+}


### PR DESCRIPTION
# Description

This pull request introduces a dedicated sort property resolver for the backup module, providing a clean mapping layer between API-facing sort parameters and the underlying `BackupDocument` properties. This abstraction decouples external sorting contracts from the persistence model, improving maintainability while allowing the API to expose consistent and stable sort field names.

# Main Changes

- Implemented a dedicated `BackupSortPropertyResolver` component to translate API sort properties into their corresponding MongoDB document fields.
- Introduced the `BackupSortProperty` enum as the single source of truth for sort property mappings.
- Integrated the sort resolver into the backup pagination flow, ensuring all pageable requests are normalized before reaching the repository layer.
- Decoupled client-facing sort parameters from internal persistence field names, preventing direct exposure of database-specific property names.
- Leveraged the shared `SortPropertyResolver` infrastructure, making the backup module consistent with a reusable sorting strategy.

# Minimal Changes

- Added dependency injection for the `SortPropertyResolver` within the backup page use case.
- Wrapped incoming `Pageable` instances before executing repository queries.
- Centralized sort property definitions into an enum to eliminate hardcoded mapping values.
- Improved code readability by separating sorting concerns from business logic.

# Notes

- The resolver provides a clear separation between the API contract and the persistence layer, allowing entity property names to evolve without introducing breaking API changes.
- Adding new sortable fields now only requires updating the `BackupSortProperty` enum, eliminating the need to modify service or repository logic.
- The generic `SortPropertyResolver` contract can be reused by other modules, promoting a consistent and scalable sorting strategy across the application.