### PR TITLE
Subscriber notifications

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/notification/api/SubscriberNotificationController.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/api/SubscriberNotificationController.java
@@ -1,0 +1,61 @@
+package com.jame.dev.gymApp.features.notification.api;
+
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationRequest;
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationUpdateRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.CreateSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.DeleteSubscriberNotificationById;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.UpdateSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.application.usecases.query.GetByIdSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.infrastructure.annotation.NotNullObject;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/app/v1/notifications")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('USER')")
+@Validated
+public class SubscriberNotificationController {
+   private final GetByIdSubscriberNotificationUseCase getById;
+   private final CreateSubscriberNotificationUseCase create;
+   private final UpdateSubscriberNotificationUseCase update;
+   private final DeleteSubscriberNotificationById delete;
+
+   @GetMapping("/{id}")
+   public ResponseEntity<SubscriberNotificationResponse> getById(@PathVariable final UUID id) {
+      return ResponseEntity.ok(getById.getById(id));
+   }
+
+   @PostMapping
+   public ResponseEntity<SubscriberNotificationResponse> create(
+      @RequestBody @Valid @NotNullObject final SubscriberNotificationRequest request) {
+      final SubscriberNotificationResponse response = create.createSubscriberNotification(request);
+      final URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+         .path("/{id}")
+         .buildAndExpand(response.uuid())
+         .toUri();
+      return ResponseEntity.created(location).body(response);
+   }
+
+   @PatchMapping("/{id}")
+   public ResponseEntity<SubscriberNotificationResponse> update(
+      @PathVariable final UUID id,
+      @RequestBody @Valid @NotNullObject final SubscriberNotificationUpdateRequest request) {
+      return ResponseEntity.ok(update.updateSubscriberNotification(id, request));
+   }
+
+   @DeleteMapping("/{id}")
+   public ResponseEntity<Void> delete(@PathVariable final UUID id) {
+      delete.deleteSubscriberNotificationById(id);
+      return ResponseEntity.noContent().build();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/api/request/SubscriberNotificationRequest.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/api/request/SubscriberNotificationRequest.java
@@ -1,0 +1,14 @@
+package com.jame.dev.gymApp.features.notification.api.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.infrastructure.annotation.Minimum;
+import jakarta.validation.constraints.Max;
+
+public record SubscriberNotificationRequest(
+   @JsonProperty("subscriptionId")
+   @Minimum long subscriptionId,
+   @JsonProperty("rangeDays")
+   @Minimum
+   @Max(value = 7, message = "Value must be min or equal than 7.") int rangeDays
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/api/request/SubscriberNotificationUpdateRequest.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/api/request/SubscriberNotificationUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.features.notification.api.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.jame.dev.gymApp.infrastructure.annotation.Minimum;
+import jakarta.validation.constraints.Max;
+
+public record SubscriberNotificationUpdateRequest(
+   @JsonProperty("rangeDays")
+   @Minimum
+   @Max(value = 7, message = "Value must be min or equal than 7.")int rangeDays
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/api/response/SubscriberNotificationResponse.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/api/response/SubscriberNotificationResponse.java
@@ -1,0 +1,13 @@
+package com.jame.dev.gymApp.features.notification.api.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public record SubscriberNotificationResponse(
+   @JsonProperty("uuid") UUID uuid,
+   @JsonProperty("rangeDaysNotification") int rangeDaysNotification,
+   @JsonProperty("nextNotificationDate") String nextNotificationDate,
+   @JsonProperty("lastNotificationDate") String lastNotificationDate
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/contract/SubscriberNotificationFactory.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/contract/SubscriberNotificationFactory.java
@@ -1,13 +1,15 @@
 package com.jame.dev.gymApp.features.notification.application.contract;
 
-import com.jame.dev.gymApp.application.support.factories.Factory;
 import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
 import com.jame.dev.gymApp.features.notification.application.dto.SubscriberNotificationFactoryDtoInput;
 import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
 import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
 
-public interface SubscriberNotificationFactory extends Factory<
-   SubscriberNotificationEntity, SubscriberNotificationResponse, SubscriberNotificationFactoryDtoInput> {
+public interface SubscriberNotificationFactory {
+
+   SubscriberNotificationResponse createFromEntity(SubscriberNotificationEntity entity);
+
+   SubscriberNotificationEntity createFromInput(SubscriberNotificationFactoryDtoInput input);
 
    default SubscriberNotificationEntity from(SubscriptionEntity subscription, int rangeDays) {
       return SubscriberNotificationEntity.builder()

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/contract/SubscriberNotificationFactory.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/contract/SubscriberNotificationFactory.java
@@ -1,0 +1,18 @@
+package com.jame.dev.gymApp.features.notification.application.contract;
+
+import com.jame.dev.gymApp.application.support.factories.Factory;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.dto.SubscriberNotificationFactoryDtoInput;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+
+public interface SubscriberNotificationFactory extends Factory<
+   SubscriberNotificationEntity, SubscriberNotificationResponse, SubscriberNotificationFactoryDtoInput> {
+
+   default SubscriberNotificationEntity from(SubscriptionEntity subscription, int rangeDays) {
+      return SubscriberNotificationEntity.builder()
+         .subscription(subscription)
+         .rangeNotificationDays(rangeDays)
+         .build();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/dto/SubscriberNotificationFactoryDtoInput.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/dto/SubscriberNotificationFactoryDtoInput.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.features.notification.application.dto;
+
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+
+public record SubscriberNotificationFactoryDtoInput(
+   SubscriptionEntity subscription,
+   int rangeDays
+) {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/service/mutation/CreateSubscriberNotificationUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/service/mutation/CreateSubscriberNotificationUseCaseService.java
@@ -1,0 +1,46 @@
+package com.jame.dev.gymApp.features.notification.application.service.mutation;
+
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
+import com.jame.dev.gymApp.features.notification.application.dto.SubscriberNotificationFactoryDtoInput;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.CreateSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationMutationRepository;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationValidationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.infrastructure.security.lock.CheckLockProcess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@CheckLockProcess
+public class CreateSubscriberNotificationUseCaseService implements CreateSubscriberNotificationUseCase {
+   private final SubscriberNotificationMutationRepository subscriberNotificationMutationRepository;
+   private final SubscriberNotificationValidationRepository subscriberNotificationValidationRepository;
+   private final SubscriptionQueryRepository subscriptionQueryRepository;
+   private final SubscriberNotificationFactory subscriberNotificationFactory;
+
+   @Override
+   @Transactional
+   public SubscriberNotificationResponse createSubscriberNotification(SubscriberNotificationRequest request) {
+      final SubscriptionEntity subscription = subscriptionQueryRepository.findById(request.subscriptionId())
+         .orElseThrow(() -> new SubscriptionNotFoundException("Subscription not found for id: " + request.subscriptionId()));
+
+      if (subscriberNotificationValidationRepository.existsBySubscriber(subscription)) {
+         throw new NotificationException("A subscriber notification already exists for subscription id: " + request.subscriptionId());
+      }
+
+      final SubscriberNotificationEntity entity = subscriberNotificationFactory.createFromInput(
+         new SubscriberNotificationFactoryDtoInput(subscription, request.rangeDays()));
+
+      final SubscriberNotificationEntity saved = subscriberNotificationMutationRepository.save(entity);
+
+      return subscriberNotificationFactory.createFromEntity(saved);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/service/mutation/DeleteSubscriberNotificationByIdService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/service/mutation/DeleteSubscriberNotificationByIdService.java
@@ -1,0 +1,31 @@
+package com.jame.dev.gymApp.features.notification.application.service.mutation;
+
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.DeleteSubscriberNotificationById;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationMutationRepository;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationValidationRepository;
+import com.jame.dev.gymApp.features.notification.infrastructure.annotation.EvictSubscriberNotification;
+import com.jame.dev.gymApp.infrastructure.security.lock.CheckLockProcess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@CheckLockProcess
+public class DeleteSubscriberNotificationByIdService implements DeleteSubscriberNotificationById {
+   private final SubscriberNotificationValidationRepository subscriberNotificationValidationRepository;
+   private final SubscriberNotificationMutationRepository subscriberNotificationMutationRepository;
+
+   @Override
+   @Transactional
+   @EvictSubscriberNotification
+   public void deleteSubscriberNotificationById(UUID uuid) {
+      if (!subscriberNotificationValidationRepository.existsById(uuid)) {
+         throw new NotificationException("Subscriber notification not found for id: " + uuid);
+      }
+      subscriberNotificationMutationRepository.deleteById(uuid);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/service/mutation/UpdateSubscriberNotificationUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/service/mutation/UpdateSubscriberNotificationUseCaseService.java
@@ -1,0 +1,42 @@
+package com.jame.dev.gymApp.features.notification.application.service.mutation;
+
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationUpdateRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.UpdateSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationMutationRepository;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationQueryRepository;
+import com.jame.dev.gymApp.features.notification.infrastructure.annotation.EvictSubscriberNotification;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import com.jame.dev.gymApp.infrastructure.security.lock.CheckLockProcess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@CheckLockProcess
+public class UpdateSubscriberNotificationUseCaseService implements UpdateSubscriberNotificationUseCase {
+   private final SubscriberNotificationQueryRepository subscriberNotificationQueryRepository;
+   private final SubscriberNotificationMutationRepository subscriberNotificationMutationRepository;
+   private final SubscriptionQueryRepository subscriptionQueryRepository;
+   private final SubscriberNotificationFactory subscriberNotificationFactory;
+
+   @Override
+   @Transactional
+   @EvictSubscriberNotification
+   public SubscriberNotificationResponse updateSubscriberNotification(final UUID uuid, final SubscriberNotificationUpdateRequest request) {
+      final SubscriberNotificationEntity entity = subscriberNotificationQueryRepository.findById(uuid)
+         .orElseThrow(() -> new NotificationException("Subscriber notification not found for id: " + uuid));
+
+      entity.setRangeNotificationDays(request.rangeDays());
+
+      final SubscriberNotificationEntity saved = subscriberNotificationMutationRepository.save(entity);
+
+      return subscriberNotificationFactory.createFromEntity(saved);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/service/query/GetByIdSubscriberNotificationUseCaseService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/service/query/GetByIdSubscriberNotificationUseCaseService.java
@@ -1,0 +1,32 @@
+package com.jame.dev.gymApp.features.notification.application.service.query;
+
+import com.jame.dev.gymApp.domain.exception.NotFoundException;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
+import com.jame.dev.gymApp.features.notification.application.usecases.query.GetByIdSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationQueryRepository;
+import com.jame.dev.gymApp.features.notification.infrastructure.cache.SubscriberNotificationCacheValues;
+import com.jame.dev.gymApp.infrastructure.security.lock.CheckLockProcess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@CheckLockProcess
+public class GetByIdSubscriberNotificationUseCaseService implements GetByIdSubscriberNotificationUseCase {
+   private final SubscriberNotificationQueryRepository subscriberNotificationQueryRepository;
+   private final SubscriberNotificationFactory subscriberNotificationFactory;
+
+   @Override
+   @Cacheable(value = SubscriberNotificationCacheValues.VALUE, key = "uuid", unless = "#result == null")
+   public SubscriberNotificationResponse getById(UUID uuid) {
+      return subscriberNotificationQueryRepository.findById(uuid)
+         .map(subscriberNotificationFactory::createFromEntity)
+         .orElseThrow(() -> new NotFoundException("Subscriber notification not found for id: " + uuid));
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/support/factory/SubscriberNotificationApplicationFactory.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/support/factory/SubscriberNotificationApplicationFactory.java
@@ -1,26 +1,17 @@
 package com.jame.dev.gymApp.features.notification.application.support.factory;
 
-import com.jame.dev.gymApp.application.dto.PageDto;
-import com.jame.dev.gymApp.application.support.factories.PageDtoFactory;
 import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
 import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
 import com.jame.dev.gymApp.features.notification.application.dto.SubscriberNotificationFactoryDtoInput;
 import com.jame.dev.gymApp.features.notification.application.support.mapper.SubscriberNotificationMapper;
 import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class SubscriberNotificationApplicationFactory implements SubscriberNotificationFactory {
    private final SubscriberNotificationMapper subscriberNotificationMapper;
-   private final PageDtoFactory<SubscriberNotificationEntity, SubscriberNotificationResponse> pageSubscriberNotificationFactory;
-
-   @Override
-   public PageDto<SubscriberNotificationResponse> createPageFrom(Page<SubscriberNotificationEntity> page) {
-      return pageSubscriberNotificationFactory.createPageDtoFrom(page);
-   }
 
    @Override
    public SubscriberNotificationResponse createFromEntity(SubscriberNotificationEntity entity) {

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/support/factory/SubscriberNotificationApplicationFactory.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/support/factory/SubscriberNotificationApplicationFactory.java
@@ -1,0 +1,34 @@
+package com.jame.dev.gymApp.features.notification.application.support.factory;
+
+import com.jame.dev.gymApp.application.dto.PageDto;
+import com.jame.dev.gymApp.application.support.factories.PageDtoFactory;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
+import com.jame.dev.gymApp.features.notification.application.dto.SubscriberNotificationFactoryDtoInput;
+import com.jame.dev.gymApp.features.notification.application.support.mapper.SubscriberNotificationMapper;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubscriberNotificationApplicationFactory implements SubscriberNotificationFactory {
+   private final SubscriberNotificationMapper subscriberNotificationMapper;
+   private final PageDtoFactory<SubscriberNotificationEntity, SubscriberNotificationResponse> pageSubscriberNotificationFactory;
+
+   @Override
+   public PageDto<SubscriberNotificationResponse> createPageFrom(Page<SubscriberNotificationEntity> page) {
+      return pageSubscriberNotificationFactory.createPageDtoFrom(page);
+   }
+
+   @Override
+   public SubscriberNotificationResponse createFromEntity(SubscriberNotificationEntity entity) {
+      return subscriberNotificationMapper.toDto(entity);
+   }
+
+   @Override
+   public SubscriberNotificationEntity createFromInput(SubscriberNotificationFactoryDtoInput input) {
+      return subscriberNotificationMapper.toEntity(input);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/support/mapper/SubscriberNotificationMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/support/mapper/SubscriberNotificationMapper.java
@@ -1,0 +1,33 @@
+package com.jame.dev.gymApp.features.notification.application.support.mapper;
+
+import com.jame.dev.gymApp.application.support.mapper.BaseMapper;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.dto.SubscriberNotificationFactoryDtoInput;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.time.LocalDateTime;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface SubscriberNotificationMapper extends BaseMapper<SubscriberNotificationEntity, SubscriberNotificationResponse> {
+
+   @Override
+   @Mapping(target = "uuid", source = "entity.id")
+   @Mapping(target = "rangeDaysNotification", source = "entity.rangeNotificationDays")
+   @Mapping(target = "nextNotificationDate", source = "entity.nextNotificationDate", dateFormat = "EEEE, MMMM dd, yyyy")
+   @Mapping(target = "lastNotificationDate", source = "entity.lastNotificationDate", dateFormat = "EEEE, MMMM dd, yyyy")
+   SubscriberNotificationResponse toDto(SubscriberNotificationEntity entity);
+
+   default SubscriberNotificationEntity toEntity(SubscriberNotificationFactoryDtoInput input) {
+      final SubscriptionEntity subscription = input.subscription();
+      final var endingPeriod = subscription.getSubscriptionPeriods().getLast().getEndPeriod();
+      return SubscriberNotificationEntity.builder()
+         .subscription(input.subscription())
+         .rangeNotificationDays(input.rangeDays())
+         .nextNotificationDate(LocalDateTime.from(endingPeriod).minusDays(input.rangeDays()))
+         .build();
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/mutation/CreateSubscriberNotificationUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/mutation/CreateSubscriberNotificationUseCase.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.features.notification.application.usecases.mutation;
+
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+
+public interface CreateSubscriberNotificationUseCase {
+   SubscriberNotificationResponse createSubscriberNotification(final SubscriberNotificationRequest request);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/mutation/DeleteSubscriberNotificationById.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/mutation/DeleteSubscriberNotificationById.java
@@ -1,0 +1,8 @@
+package com.jame.dev.gymApp.features.notification.application.usecases.mutation;
+
+import java.util.UUID;
+
+public interface DeleteSubscriberNotificationById {
+
+   void deleteSubscriberNotificationById(final UUID uuid);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/mutation/UpdateSubscriberNotificationUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/mutation/UpdateSubscriberNotificationUseCase.java
@@ -1,0 +1,10 @@
+package com.jame.dev.gymApp.features.notification.application.usecases.mutation;
+
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationUpdateRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+
+import java.util.UUID;
+
+public interface UpdateSubscriberNotificationUseCase {
+   SubscriberNotificationResponse updateSubscriberNotification(final UUID uuid, final SubscriberNotificationUpdateRequest request);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/query/GetByIdSubscriberNotificationUseCase.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/usecases/query/GetByIdSubscriberNotificationUseCase.java
@@ -1,0 +1,9 @@
+package com.jame.dev.gymApp.features.notification.application.usecases.query;
+
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+
+import java.util.UUID;
+
+public interface GetByIdSubscriberNotificationUseCase {
+   SubscriberNotificationResponse getById(final UUID uuid);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/domain/model/SubscriberNotificationEntity.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/domain/model/SubscriberNotificationEntity.java
@@ -1,0 +1,55 @@
+package com.jame.dev.gymApp.features.notification.domain.model;
+
+
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "subscriber_notifications")
+public class SubscriberNotificationEntity {
+
+   @Id
+   @GeneratedValue(strategy = GenerationType.UUID)
+   @Column(name = "id", updatable = false, nullable = false, unique = true)
+   private UUID id;
+
+   @OneToOne(
+      fetch = FetchType.LAZY,
+      cascade = {CascadeType.MERGE, CascadeType.REMOVE},
+      optional = false)
+   @JoinColumn(
+      name = "subscription_id",
+      nullable = false,
+      unique = true,
+      foreignKey = @ForeignKey(
+         name = "fk_subscription_notication",
+         foreignKeyDefinition = "FOREIGN KEY (subscription_id) REFERENCES subscriptions (id) ON DELETE CASCADE"
+      )
+   )
+   @NonNull
+   private SubscriptionEntity subscription;
+
+   @Column(name = "range_notification_days")
+   @Builder.Default
+   @Min(value = 1, message = "Minium value allowed is 1.")
+   @Max(value = 7,message = "Maximum value allowed is 7.")
+   private int rangeNotificationDays = 7;
+
+   @Column(name = "next_notifiaction_date", nullable = false)
+   private LocalDateTime nextNotificationDate;
+
+   @Column(name = "last_notification_date")
+   private LocalDateTime lastNotificationDate;
+
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/domain/repository/SubscriberNotificationMutationRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/domain/repository/SubscriberNotificationMutationRepository.java
@@ -1,0 +1,13 @@
+package com.jame.dev.gymApp.features.notification.domain.repository;
+
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+
+import java.util.UUID;
+
+public interface SubscriberNotificationMutationRepository {
+
+   SubscriberNotificationEntity save(final SubscriberNotificationEntity entity);
+
+   void deleteById(final UUID uuid);
+
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/domain/repository/SubscriberNotificationQueryRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/domain/repository/SubscriberNotificationQueryRepository.java
@@ -1,0 +1,15 @@
+package com.jame.dev.gymApp.features.notification.domain.repository;
+
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SubscriberNotificationQueryRepository {
+
+   Optional<SubscriberNotificationEntity> findById(final UUID uuid);
+
+   Optional<SubscriberNotificationEntity> findBySubscriber(final SubscriptionEntity subscriptionEntity);
+
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/domain/repository/SubscriberNotificationValidationRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/domain/repository/SubscriberNotificationValidationRepository.java
@@ -1,0 +1,12 @@
+package com.jame.dev.gymApp.features.notification.domain.repository;
+
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+
+import java.util.UUID;
+
+public interface SubscriberNotificationValidationRepository {
+
+   boolean existsById(final UUID uuid);
+
+   boolean existsBySubscriber(final SubscriptionEntity subscriptionEntity);
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/adapter/SubscriberNotificationMutationJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/adapter/SubscriberNotificationMutationJpaRepositoryAdapter.java
@@ -1,0 +1,25 @@
+package com.jame.dev.gymApp.features.notification.infrastructure.adapter;
+
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationMutationRepository;
+import com.jame.dev.gymApp.features.notification.infrastructure.persistence.SubscriberNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriberNotificationMutationJpaRepositoryAdapter implements SubscriberNotificationMutationRepository {
+   private final SubscriberNotificationRepository subscriberNotificationRepository;
+
+   @Override
+   public SubscriberNotificationEntity save(SubscriberNotificationEntity entity) {
+      return subscriberNotificationRepository.saveAndFlush(entity);
+   }
+
+   @Override
+   public void deleteById(UUID uuid) {
+      subscriberNotificationRepository.deleteById(uuid);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/adapter/SubscriberNotificationQueryJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/adapter/SubscriberNotificationQueryJpaRepositoryAdapter.java
@@ -1,0 +1,27 @@
+package com.jame.dev.gymApp.features.notification.infrastructure.adapter;
+
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationQueryRepository;
+import com.jame.dev.gymApp.features.notification.infrastructure.persistence.SubscriberNotificationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriberNotificationQueryJpaRepositoryAdapter implements SubscriberNotificationQueryRepository {
+   private final SubscriberNotificationRepository subscriberNotificationRepository;
+
+   @Override
+   public Optional<SubscriberNotificationEntity> findById(UUID uuid) {
+      return subscriberNotificationRepository.findById(uuid);
+   }
+
+   @Override
+   public Optional<SubscriberNotificationEntity> findBySubscriber(SubscriptionEntity subscriptionEntity) {
+      return subscriberNotificationRepository.findBySubscription(subscriptionEntity);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/adapter/SubscriberNotificationValidationJpaRepositoryAdapter.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/adapter/SubscriberNotificationValidationJpaRepositoryAdapter.java
@@ -1,0 +1,25 @@
+package com.jame.dev.gymApp.features.notification.infrastructure.adapter;
+
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationValidationRepository;
+import com.jame.dev.gymApp.features.notification.infrastructure.persistence.SubscriberNotificationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class SubscriberNotificationValidationJpaRepositoryAdapter implements SubscriberNotificationValidationRepository {
+   private final SubscriberNotificationRepository subscriberNotificationRepository;
+
+   @Override
+   public boolean existsById(UUID uuid) {
+      return subscriberNotificationRepository.existsById(uuid);
+   }
+
+   @Override
+   public boolean existsBySubscriber(SubscriptionEntity subscriptionEntity) {
+      return subscriberNotificationRepository.existsBySubscription(subscriptionEntity);
+   }
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/annotation/EvictSubscriberNotification.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/annotation/EvictSubscriberNotification.java
@@ -1,0 +1,18 @@
+package com.jame.dev.gymApp.features.notification.infrastructure.annotation;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
+
+import java.lang.annotation.*;
+
+import static com.jame.dev.gymApp.features.notification.infrastructure.cache.SubscriberNotificationCacheValues.VALUE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target(ElementType.METHOD)
+@Inherited
+@Caching(
+   evict = @CacheEvict(value = VALUE, key = "#uuid")
+)
+public @interface EvictSubscriberNotification {
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/cache/SubscriberNotificationCacheValues.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/cache/SubscriberNotificationCacheValues.java
@@ -1,0 +1,5 @@
+package com.jame.dev.gymApp.features.notification.infrastructure.cache;
+
+public class SubscriberNotificationCacheValues {
+   public static final String VALUE = "subscriber:notification:uuid";
+}

--- a/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/persistence/SubscriberNotificationRepository.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/infrastructure/persistence/SubscriberNotificationRepository.java
@@ -1,0 +1,13 @@
+package com.jame.dev.gymApp.features.notification.infrastructure.persistence;
+
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SubscriberNotificationRepository extends JpaRepository<SubscriberNotificationEntity, UUID> {
+    Optional<SubscriberNotificationEntity> findBySubscription(final SubscriptionEntity subscription);
+    boolean existsBySubscription(final SubscriptionEntity subscription);
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/SubscriberNotificationTestData.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/SubscriberNotificationTestData.java
@@ -1,0 +1,32 @@
+package com.jame.dev.gymApp.notification;
+
+public interface SubscriberNotificationTestData {
+
+   String UUID_RESOURCE_ERRORS = """
+           VALUE,    ERROR_CODE
+           0,        TYPE_MISMATCH
+           -100,     TYPE_MISMATCH
+           letters,  TYPE_MISMATCH
+           NULL,     TYPE_MISMATCH
+           """;
+
+   String NOTIFICATION_PAYLOAD_VALIDATIONS_ERRORS = """
+           SUBSCRIPTION_ID, RANGE_DAYS, ERROR_CODE
+           NULL,            3,          VALIDATION_OPERATION
+           1,               0,          VALIDATION_OPERATION
+           1,               8,          VALIDATION_OPERATION
+           """;
+
+   String NOTIFICATION_UPDATE_PAYLOAD_VALIDATIONS_ERRORS = """
+           RANGE_DAYS, ERROR_CODE
+           NULL,       VALIDATION_OPERATION
+           0,          VALIDATION_OPERATION
+           8,          VALIDATION_OPERATION
+           """;
+
+   String BODY_FORMAT_ERRORS = """
+           VALUE,  ERROR_CODE
+           {NULL},   VALIDATION_OPERATION
+           {EMPTY},  VALIDATION_OPERATION
+           """;
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/controller/SubscriberNotificationControllerTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/controller/SubscriberNotificationControllerTest.java
@@ -1,0 +1,344 @@
+package com.jame.dev.gymApp.notification.controller;
+
+import com.jame.dev.gymApp.features.notification.api.SubscriberNotificationController;
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationRequest;
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationUpdateRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.CreateSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.DeleteSubscriberNotificationById;
+import com.jame.dev.gymApp.features.notification.application.usecases.mutation.UpdateSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.application.usecases.query.GetByIdSubscriberNotificationUseCase;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.presentation.exception.GlobalExceptionHandler;
+import config.TestConfig;
+import config.TestValidationConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+   controllers = SubscriberNotificationController.class,
+   excludeFilters = {
+      @ComponentScan.Filter(
+         type = FilterType.ASSIGNABLE_TYPE,
+         classes = com.jame.dev.gymApp.features.auth.infrastructure.security.CustomAuthorizationFilter.class
+      )}
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({
+   GlobalExceptionHandler.class,
+   TestValidationConfig.class,
+   TestConfig.class})
+@ImportAutoConfiguration({ValidationAutoConfiguration.class})
+class SubscriberNotificationControllerTest {
+
+   @Autowired
+   private MockMvc mockMvc;
+
+   @MockitoBean
+   private GetByIdSubscriberNotificationUseCase getById;
+
+   @MockitoBean
+   private CreateSubscriberNotificationUseCase create;
+
+   @MockitoBean
+   private UpdateSubscriberNotificationUseCase update;
+
+   @MockitoBean
+   private DeleteSubscriberNotificationById delete;
+
+   private final String URI_TEMPLATE = "/app/v1/notifications";
+
+   private final UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+   private final SubscriberNotificationResponse response = new SubscriberNotificationResponse(
+      uuid, 3, "2026-01-01T00:00:00", null
+   );
+
+   @Nested
+   @DisplayName("GET: /app/v1/notifications/{id}")
+   class GetSubscriberNotificationTests {
+
+      @Test
+      @DisplayName("GET[200] OK: /notifications/{uuid}")
+      void getById() throws Exception {
+         given(getById.getById(uuid)).willReturn(response);
+
+         mockMvc.perform(get(URI_TEMPLATE + "/" + uuid)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uuid").value(uuid.toString()));
+
+         then(getById).should(times(1)).getById(uuid);
+      }
+
+      @Test
+      @DisplayName("GET[404] Not Found: /notifications/{uuid}")
+      void getByIdNotFound() throws Exception {
+         given(getById.getById(uuid)).willThrow(NotificationException.class);
+
+         mockMvc.perform(get(URI_TEMPLATE + "/" + uuid)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists());
+
+         then(getById).should(times(1)).getById(uuid);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true, textBlock = """
+              VALUE,    ERROR_CODE
+              0,        TYPE_MISMATCH
+              -100,     TYPE_MISMATCH
+              letters,  TYPE_MISMATCH
+              NULL,     TYPE_MISMATCH
+              """)
+      @DisplayName("GET[400] Bad Request: /notifications/{invalidId}")
+      void badRequestInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(get(URI_TEMPLATE + "/" + value)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+
+         then(getById).shouldHaveNoInteractions();
+      }
+   }
+
+   @Nested
+   @DisplayName("POST: /app/v1/notifications")
+   class PostSubscriberNotificationTests {
+
+      private final String payload = """
+         {
+            "subscriptionId": 1,
+            "rangeDays": 3
+         }
+         """;
+
+      @Test
+      @DisplayName("POST[201] Created")
+      void create() throws Exception {
+         given(create.createSubscriberNotification(any(SubscriberNotificationRequest.class)))
+            .willReturn(response);
+
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", org.hamcrest.Matchers.endsWith("/" + uuid)))
+            .andExpect(jsonPath("$.uuid").value(uuid.toString()));
+
+         then(create).should(times(1)).createSubscriberNotification(any(SubscriberNotificationRequest.class));
+      }
+
+      @Test
+      @DisplayName("POST[404] Not Found: Subscription does not exist")
+      void createSubscriptionNotFound() throws Exception {
+         given(create.createSubscriberNotification(any(SubscriberNotificationRequest.class)))
+            .willThrow(SubscriptionNotFoundException.class);
+
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(404));
+
+         then(create).should(times(1)).createSubscriberNotification(any(SubscriberNotificationRequest.class));
+      }
+
+      @Test
+      @DisplayName("POST[409] Conflict: Notification already exists")
+      void createAlreadyExists() throws Exception {
+         given(create.createSubscriberNotification(any(SubscriberNotificationRequest.class)))
+            .willThrow(NotificationException.class);
+
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(409));
+
+         then(create).should(times(1)).createSubscriberNotification(any(SubscriberNotificationRequest.class));
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true, textBlock = """
+              VALUE,  ERROR_CODE
+              {NULL},   VALIDATION_OPERATION
+              {EMPTY},  VALIDATION_OPERATION
+              """)
+      @DisplayName("POST[400] Bad Request: Invalid payload format")
+      void badRequestInvalidPayload(String value, String codeExpected) throws Exception {
+         mockMvc.perform(post(URI_TEMPLATE)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(value))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+
+         then(create).shouldHaveNoInteractions();
+      }
+   }
+
+   @Nested
+   @DisplayName("PATCH: /app/v1/notifications/{id}")
+   class PatchSubscriberNotificationTests {
+
+      private final String payload = """
+         {
+            "rangeDays": 5
+         }
+         """;
+
+      @Test
+      @DisplayName("PATCH[200] OK: Update range days")
+      void patchRangeDays() throws Exception {
+         given(update.updateSubscriberNotification(
+            any(UUID.class), any(SubscriberNotificationUpdateRequest.class)))
+            .willReturn(response);
+
+         mockMvc.perform(patch(URI_TEMPLATE + "/" + uuid)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.uuid").value(uuid.toString()));
+
+         then(update).should(times(1))
+            .updateSubscriberNotification(any(UUID.class), any(SubscriberNotificationUpdateRequest.class));
+      }
+
+      @Test
+      @DisplayName("PATCH[404] Not Found: Notification not found")
+      void patchRangeDaysNotFound() throws Exception {
+         given(update.updateSubscriberNotification(
+            any(UUID.class), any(SubscriberNotificationUpdateRequest.class)))
+            .willThrow(NotificationException.class);
+
+         mockMvc.perform(patch(URI_TEMPLATE + "/" + uuid)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(404));
+
+         then(update).should(times(1))
+            .updateSubscriberNotification(any(UUID.class), any(SubscriberNotificationUpdateRequest.class));
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true, textBlock = """
+              VALUE,    ERROR_CODE
+              0,        TYPE_MISMATCH
+              -100,     TYPE_MISMATCH
+              letters,  TYPE_MISMATCH
+              NULL,     TYPE_MISMATCH
+              """)
+      @DisplayName("PATCH[400] Bad Request: /notifications/{invalidId}")
+      void patchInvalidIdPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(patch(URI_TEMPLATE + "/" + value)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+
+         then(update).shouldHaveNoInteractions();
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true, textBlock = """
+              VALUE,  ERROR_CODE
+              {NULL},   VALIDATION_OPERATION
+              {EMPTY},  VALIDATION_OPERATION
+              """)
+      @DisplayName("PATCH[400] Bad Request: Invalid payload format")
+      void patchInvalidPayload(String value, String codeExpected) throws Exception {
+         mockMvc.perform(patch(URI_TEMPLATE + "/" + uuid)
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(value))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(codeExpected));
+
+         then(update).shouldHaveNoInteractions();
+      }
+   }
+
+   @Nested
+   @DisplayName("DELETE: /app/v1/notifications/{id}")
+   class DeleteSubscriberNotificationTests {
+
+      @Test
+      @DisplayName("DELETE[204] No Content")
+      void deleteNotification() throws Exception {
+         mockMvc.perform(delete(URI_TEMPLATE + "/" + uuid))
+            .andExpect(status().isNoContent())
+            .andExpect(jsonPath("$.*").doesNotExist());
+
+         then(delete).should(times(1)).deleteSubscriberNotificationById(uuid);
+      }
+
+      @Test
+      @DisplayName("DELETE[404] Not Found: Notification not found")
+      void deleteNotificationNotFound() throws Exception {
+         willThrow(NotificationException.class)
+            .given(delete).deleteSubscriberNotificationById(uuid);
+
+         mockMvc.perform(delete(URI_TEMPLATE + "/" + uuid))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(404));
+
+         then(delete).should(times(1)).deleteSubscriberNotificationById(uuid);
+      }
+
+      @ParameterizedTest
+      @CsvSource(useHeadersInDisplayName = true, textBlock = """
+              VALUE,    ERROR_CODE
+              0,        TYPE_MISMATCH
+              -100,     TYPE_MISMATCH
+              letters,  TYPE_MISMATCH
+              NULL,     TYPE_MISMATCH
+              """)
+      @DisplayName("DELETE[400] Bad Request: /notifications/{invalidId}")
+      void deleteInvalidPathVariable(String value, String expectedCode) throws Exception {
+         mockMvc.perform(delete(URI_TEMPLATE + "/" + value)
+               .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.*").exists())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.code").value(expectedCode));
+
+         then(delete).shouldHaveNoInteractions();
+      }
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/repository/SubscriberNotificationMutationJpaRepositoryAdapterTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/repository/SubscriberNotificationMutationJpaRepositoryAdapterTest.java
@@ -1,0 +1,50 @@
+package com.jame.dev.gymApp.notification.repository;
+
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.infrastructure.adapter.SubscriberNotificationMutationJpaRepositoryAdapter;
+import com.jame.dev.gymApp.features.notification.infrastructure.persistence.SubscriberNotificationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriberNotificationMutationJpaRepositoryAdapterTest {
+
+   @Mock
+   private SubscriberNotificationRepository subscriberNotificationRepository;
+
+   @InjectMocks
+   private SubscriberNotificationMutationJpaRepositoryAdapter adapter;
+
+   @Test
+   @DisplayName("Should delegate save to JPA repository with saveAndFlush")
+   void save_delegatesToJpaRepository() {
+      var entity = new SubscriberNotificationEntity();
+      given(subscriberNotificationRepository.saveAndFlush(entity)).willReturn(entity);
+
+      adapter.save(entity);
+
+      verify(subscriberNotificationRepository).saveAndFlush(entity);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+
+   @Test
+   @DisplayName("Should delegate deleteById to JPA repository")
+   void deleteById_delegatesToJpaRepository() {
+      var uuid = UUID.randomUUID();
+
+      adapter.deleteById(uuid);
+
+      verify(subscriberNotificationRepository).deleteById(uuid);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/repository/SubscriberNotificationQueryJpaRepositoryAdapterTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/repository/SubscriberNotificationQueryJpaRepositoryAdapterTest.java
@@ -1,0 +1,86 @@
+package com.jame.dev.gymApp.notification.repository;
+
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.infrastructure.adapter.SubscriberNotificationQueryJpaRepositoryAdapter;
+import com.jame.dev.gymApp.features.notification.infrastructure.persistence.SubscriberNotificationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriberNotificationQueryJpaRepositoryAdapterTest {
+
+   @Mock
+   private SubscriberNotificationRepository subscriberNotificationRepository;
+
+   @InjectMocks
+   private SubscriberNotificationQueryJpaRepositoryAdapter adapter;
+
+   @Test
+   @DisplayName("Should delegate findById to JPA repository")
+   void findById_delegatesToJpaRepository() {
+      var uuid = UUID.randomUUID();
+      var entity = new SubscriberNotificationEntity();
+      given(subscriberNotificationRepository.findById(uuid)).willReturn(Optional.of(entity));
+
+      var result = adapter.findById(uuid);
+
+      assertTrue(result.isPresent());
+      assertSame(entity, result.get());
+      verify(subscriberNotificationRepository).findById(uuid);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+
+   @Test
+   @DisplayName("Should return empty when JPA repository returns empty")
+   void findById_whenNotFound_returnsEmpty() {
+      var uuid = UUID.randomUUID();
+      given(subscriberNotificationRepository.findById(uuid)).willReturn(Optional.empty());
+
+      var result = adapter.findById(uuid);
+
+      assertTrue(result.isEmpty());
+      verify(subscriberNotificationRepository).findById(uuid);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+
+   @Test
+   @DisplayName("Should delegate findBySubscriber to JPA repository")
+   void findBySubscriber_delegatesToJpaRepository() {
+      var subscription = new SubscriptionEntity();
+      var entity = new SubscriberNotificationEntity();
+      given(subscriberNotificationRepository.findBySubscription(subscription)).willReturn(Optional.of(entity));
+
+      var result = adapter.findBySubscriber(subscription);
+
+      assertTrue(result.isPresent());
+      assertSame(entity, result.get());
+      verify(subscriberNotificationRepository).findBySubscription(subscription);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+
+   @Test
+   @DisplayName("Should return empty when subscription has no notification")
+   void findBySubscriber_whenNotFound_returnsEmpty() {
+      var subscription = new SubscriptionEntity();
+      given(subscriberNotificationRepository.findBySubscription(subscription)).willReturn(Optional.empty());
+
+      var result = adapter.findBySubscriber(subscription);
+
+      assertTrue(result.isEmpty());
+      verify(subscriberNotificationRepository).findBySubscription(subscription);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/repository/SubscriberNotificationValidationJpaRepositoryAdapterTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/repository/SubscriberNotificationValidationJpaRepositoryAdapterTest.java
@@ -1,0 +1,79 @@
+package com.jame.dev.gymApp.notification.repository;
+
+import com.jame.dev.gymApp.features.notification.infrastructure.adapter.SubscriberNotificationValidationJpaRepositoryAdapter;
+import com.jame.dev.gymApp.features.notification.infrastructure.persistence.SubscriberNotificationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriberNotificationValidationJpaRepositoryAdapterTest {
+
+   @Mock
+   private SubscriberNotificationRepository subscriberNotificationRepository;
+
+   @InjectMocks
+   private SubscriberNotificationValidationJpaRepositoryAdapter adapter;
+
+   @Test
+   @DisplayName("Should delegate existsById to JPA repository")
+   void existsById_delegatesToJpaRepository() {
+      var uuid = UUID.randomUUID();
+      given(subscriberNotificationRepository.existsById(uuid)).willReturn(true);
+
+      var result = adapter.existsById(uuid);
+
+      assertTrue(result);
+      verify(subscriberNotificationRepository).existsById(uuid);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+
+   @Test
+   @DisplayName("Should return false when entity not found by id")
+   void existsById_whenNotFound_returnsFalse() {
+      var uuid = UUID.randomUUID();
+      given(subscriberNotificationRepository.existsById(uuid)).willReturn(false);
+
+      var result = adapter.existsById(uuid);
+
+      assertFalse(result);
+      verify(subscriberNotificationRepository).existsById(uuid);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+
+   @Test
+   @DisplayName("Should delegate existsBySubscriber to JPA repository")
+   void existsBySubscriber_delegatesToJpaRepository() {
+      var subscription = new SubscriptionEntity();
+      given(subscriberNotificationRepository.existsBySubscription(subscription)).willReturn(true);
+
+      var result = adapter.existsBySubscriber(subscription);
+
+      assertTrue(result);
+      verify(subscriberNotificationRepository).existsBySubscription(subscription);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+
+   @Test
+   @DisplayName("Should return false when subscription has no notification")
+   void existsBySubscriber_whenNotFound_returnsFalse() {
+      var subscription = new SubscriptionEntity();
+      given(subscriberNotificationRepository.existsBySubscription(subscription)).willReturn(false);
+
+      var result = adapter.existsBySubscriber(subscription);
+
+      assertFalse(result);
+      verify(subscriberNotificationRepository).existsBySubscription(subscription);
+      verifyNoMoreInteractions(subscriberNotificationRepository);
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/usecases/mutation/CreateSubscriberNotificationUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/usecases/mutation/CreateSubscriberNotificationUseCaseServiceTest.java
@@ -1,0 +1,109 @@
+package com.jame.dev.gymApp.notification.usecases.mutation;
+
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
+import com.jame.dev.gymApp.features.notification.application.dto.SubscriberNotificationFactoryDtoInput;
+import com.jame.dev.gymApp.features.notification.application.service.mutation.CreateSubscriberNotificationUseCaseService;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationMutationRepository;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationValidationRepository;
+import com.jame.dev.gymApp.features.subscription.domain.exception.SubscriptionNotFoundException;
+import com.jame.dev.gymApp.features.subscription.domain.model.SubscriptionEntity;
+import com.jame.dev.gymApp.features.subscription.domain.repository.SubscriptionQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateSubscriberNotificationUseCaseServiceTest {
+
+   @Mock
+   private SubscriberNotificationMutationRepository subscriberNotificationMutationRepository;
+
+   @Mock
+   private SubscriberNotificationValidationRepository subscriberNotificationValidationRepository;
+
+   @Mock
+   private SubscriptionQueryRepository subscriptionQueryRepository;
+
+   @Mock
+   private SubscriberNotificationFactory subscriberNotificationFactory;
+
+   @InjectMocks
+   private CreateSubscriberNotificationUseCaseService service;
+
+   @Captor
+   private ArgumentCaptor<SubscriberNotificationEntity> entityCaptor;
+
+   private final SubscriberNotificationRequest request = new SubscriberNotificationRequest(1L, 3);
+
+   @Test
+   @DisplayName("Should create notification when subscription exists and no duplicate")
+   void create_whenValid_createsAndReturnsResponse() {
+      var subscription = new SubscriptionEntity();
+      var entity = new SubscriberNotificationEntity();
+      var savedEntity = new SubscriberNotificationEntity();
+      var response = mock(SubscriberNotificationResponse.class);
+
+      given(subscriptionQueryRepository.findById(1L)).willReturn(Optional.of(subscription));
+      given(subscriberNotificationValidationRepository.existsBySubscriber(subscription)).willReturn(false);
+      given(subscriberNotificationFactory.createFromInput(any(SubscriberNotificationFactoryDtoInput.class)))
+         .willReturn(entity);
+      given(subscriberNotificationMutationRepository.save(entity)).willReturn(savedEntity);
+      given(subscriberNotificationFactory.createFromEntity(savedEntity)).willReturn(response);
+
+      var result = service.createSubscriberNotification(request);
+
+      assertSame(response, result);
+      verify(subscriptionQueryRepository).findById(1L);
+      verify(subscriberNotificationValidationRepository).existsBySubscriber(subscription);
+      verify(subscriberNotificationFactory).createFromInput(any(SubscriberNotificationFactoryDtoInput.class));
+      verify(subscriberNotificationMutationRepository).save(entity);
+      verify(subscriberNotificationFactory).createFromEntity(savedEntity);
+      verifyNoMoreInteractions(subscriberNotificationMutationRepository,
+         subscriberNotificationValidationRepository, subscriptionQueryRepository,
+         subscriberNotificationFactory);
+   }
+
+   @Test
+   @DisplayName("Should throw SubscriptionNotFoundException when subscription not found")
+   void create_whenSubscriptionNotFound_throwsException() {
+      given(subscriptionQueryRepository.findById(1L)).willReturn(Optional.empty());
+
+      assertThrows(SubscriptionNotFoundException.class,
+         () -> service.createSubscriberNotification(request));
+
+      verify(subscriptionQueryRepository).findById(1L);
+      verifyNoInteractions(subscriberNotificationValidationRepository,
+         subscriberNotificationMutationRepository, subscriberNotificationFactory);
+   }
+
+   @Test
+   @DisplayName("Should throw NotificationException when notification already exists")
+   void create_whenAlreadyExists_throwsException() {
+      var subscription = new SubscriptionEntity();
+      given(subscriptionQueryRepository.findById(1L)).willReturn(Optional.of(subscription));
+      given(subscriberNotificationValidationRepository.existsBySubscriber(subscription)).willReturn(true);
+
+      assertThrows(NotificationException.class,
+         () -> service.createSubscriberNotification(request));
+
+      verify(subscriptionQueryRepository).findById(1L);
+      verify(subscriberNotificationValidationRepository).existsBySubscriber(subscription);
+      verifyNoInteractions(subscriberNotificationMutationRepository, subscriberNotificationFactory);
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/usecases/mutation/DeleteSubscriberNotificationByIdServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/usecases/mutation/DeleteSubscriberNotificationByIdServiceTest.java
@@ -1,0 +1,59 @@
+package com.jame.dev.gymApp.notification.usecases.mutation;
+
+import com.jame.dev.gymApp.features.notification.application.service.mutation.DeleteSubscriberNotificationByIdService;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationMutationRepository;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationValidationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteSubscriberNotificationByIdServiceTest {
+
+   @Mock
+   private SubscriberNotificationValidationRepository subscriberNotificationValidationRepository;
+
+   @Mock
+   private SubscriberNotificationMutationRepository subscriberNotificationMutationRepository;
+
+   @InjectMocks
+   private DeleteSubscriberNotificationByIdService service;
+
+   @Test
+   @DisplayName("Should delete when notification exists")
+   void deleteById_whenExists_deletes() {
+      var uuid = UUID.randomUUID();
+      given(subscriberNotificationValidationRepository.existsById(uuid)).willReturn(true);
+
+      service.deleteSubscriberNotificationById(uuid);
+
+      verify(subscriberNotificationValidationRepository).existsById(uuid);
+      verify(subscriberNotificationMutationRepository).deleteById(uuid);
+      verifyNoMoreInteractions(subscriberNotificationValidationRepository,
+         subscriberNotificationMutationRepository);
+   }
+
+   @Test
+   @DisplayName("Should throw NotificationException when notification not found")
+   void deleteById_whenNotFound_throwsException() {
+      var uuid = UUID.randomUUID();
+      given(subscriberNotificationValidationRepository.existsById(uuid)).willReturn(false);
+
+      assertThrows(NotificationException.class,
+         () -> service.deleteSubscriberNotificationById(uuid));
+
+      verify(subscriberNotificationValidationRepository).existsById(uuid);
+      verifyNoInteractions(subscriberNotificationMutationRepository);
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/usecases/mutation/UpdateSubscriberNotificationUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/usecases/mutation/UpdateSubscriberNotificationUseCaseServiceTest.java
@@ -1,0 +1,84 @@
+package com.jame.dev.gymApp.notification.usecases.mutation;
+
+import com.jame.dev.gymApp.features.notification.api.request.SubscriberNotificationUpdateRequest;
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
+import com.jame.dev.gymApp.features.notification.application.service.mutation.UpdateSubscriberNotificationUseCaseService;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationMutationRepository;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateSubscriberNotificationUseCaseServiceTest {
+
+   @Mock
+   private SubscriberNotificationQueryRepository subscriberNotificationQueryRepository;
+
+   @Mock
+   private SubscriberNotificationMutationRepository subscriberNotificationMutationRepository;
+
+   @Mock
+   private SubscriberNotificationFactory subscriberNotificationFactory;
+
+   @InjectMocks
+   private UpdateSubscriberNotificationUseCaseService service;
+
+   @Captor
+   private ArgumentCaptor<SubscriberNotificationEntity> entityCaptor;
+
+   private final SubscriberNotificationUpdateRequest request = new SubscriberNotificationUpdateRequest(5);
+
+   @Test
+   @DisplayName("Should update notification when found")
+   void update_whenFound_updatesAndReturnsResponse() {
+      var uuid = UUID.randomUUID();
+      var entity = new SubscriberNotificationEntity();
+      entity.setRangeNotificationDays(3);
+      var savedEntity = new SubscriberNotificationEntity();
+      var response = mock(SubscriberNotificationResponse.class);
+
+      given(subscriberNotificationQueryRepository.findById(uuid)).willReturn(Optional.of(entity));
+      given(subscriberNotificationMutationRepository.save(entity)).willReturn(savedEntity);
+      given(subscriberNotificationFactory.createFromEntity(savedEntity)).willReturn(response);
+
+      var result = service.updateSubscriberNotification(uuid, request);
+
+      assertSame(response, result);
+      assertEquals(5, entity.getRangeNotificationDays());
+      verify(subscriberNotificationQueryRepository).findById(uuid);
+      verify(subscriberNotificationMutationRepository).save(entity);
+      verify(subscriberNotificationFactory).createFromEntity(savedEntity);
+      verifyNoMoreInteractions(subscriberNotificationQueryRepository,
+         subscriberNotificationMutationRepository, subscriberNotificationFactory);
+   }
+
+   @Test
+   @DisplayName("Should throw NotificationException when notification not found")
+   void update_whenNotFound_throwsException() {
+      var uuid = UUID.randomUUID();
+      given(subscriberNotificationQueryRepository.findById(uuid)).willReturn(Optional.empty());
+
+      assertThrows(NotificationException.class,
+         () -> service.updateSubscriberNotification(uuid, request));
+
+      verify(subscriberNotificationQueryRepository).findById(uuid);
+      verifyNoInteractions(subscriberNotificationMutationRepository, subscriberNotificationFactory);
+   }
+}

--- a/src/test/java/com/jame/dev/gymApp/notification/usecases/query/GetByIdSubscriberNotificationUseCaseServiceTest.java
+++ b/src/test/java/com/jame/dev/gymApp/notification/usecases/query/GetByIdSubscriberNotificationUseCaseServiceTest.java
@@ -1,0 +1,65 @@
+package com.jame.dev.gymApp.notification.usecases.query;
+
+import com.jame.dev.gymApp.features.notification.api.response.SubscriberNotificationResponse;
+import com.jame.dev.gymApp.features.notification.application.contract.SubscriberNotificationFactory;
+import com.jame.dev.gymApp.features.notification.application.service.query.GetByIdSubscriberNotificationUseCaseService;
+import com.jame.dev.gymApp.features.notification.domain.exception.NotificationException;
+import com.jame.dev.gymApp.features.notification.domain.model.SubscriberNotificationEntity;
+import com.jame.dev.gymApp.features.notification.domain.repository.SubscriberNotificationQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetByIdSubscriberNotificationUseCaseServiceTest {
+
+   @Mock
+   private SubscriberNotificationQueryRepository subscriberNotificationQueryRepository;
+
+   @Mock
+   private SubscriberNotificationFactory subscriberNotificationFactory;
+
+   @InjectMocks
+   private GetByIdSubscriberNotificationUseCaseService service;
+
+   @Test
+   @DisplayName("Should return response when notification exists")
+   void getById_whenExists_returnsResponse() {
+      var uuid = UUID.randomUUID();
+      var entity = new SubscriberNotificationEntity();
+      var response = mock(SubscriberNotificationResponse.class);
+
+      given(subscriberNotificationQueryRepository.findById(uuid)).willReturn(Optional.of(entity));
+      given(subscriberNotificationFactory.createFromEntity(entity)).willReturn(response);
+
+      var result = service.getById(uuid);
+
+      assertSame(response, result);
+      verify(subscriberNotificationQueryRepository).findById(uuid);
+      verify(subscriberNotificationFactory).createFromEntity(entity);
+      verifyNoMoreInteractions(subscriberNotificationQueryRepository, subscriberNotificationFactory);
+   }
+
+   @Test
+   @DisplayName("Should throw NotificationException when notification not found")
+   void getById_whenNotFound_throwsException() {
+      var uuid = UUID.randomUUID();
+      given(subscriberNotificationQueryRepository.findById(uuid)).willReturn(Optional.empty());
+
+      assertThrows(NotificationException.class, () -> service.getById(uuid));
+
+      verify(subscriberNotificationQueryRepository).findById(uuid);
+      verifyNoInteractions(subscriberNotificationFactory);
+   }
+}


### PR DESCRIPTION
# Description

This PR introduces the foundation for a configurable subscriber notification system by implementing the new `SubscriberNotificationEntity` and its complete application flow. It enables users to define how many days in advance they want to be notified before their subscription expires, establishing the groundwork for an automated notification process that can later be integrated with scheduled jobs and multiple notification channels.

---

# Main Changes

- Implemented the new `SubscriberNotificationEntity` to persist notification preferences linked to a subscription.
- Added a complete Notification module following the project's architecture, including:
  - Domain repositories and validation contracts.
  - JPA repository adapters.
  - Factory and MapStruct mapper implementations.
  - Application services and use cases.
- Implemented CRUD REST endpoints for subscriber notifications:
  - Create notification configuration.
  - Retrieve notification configuration by UUID.
  - Update notification range.
  - Delete notification configuration.
- Added request and response DTOs with validation rules for notification configuration.
- Implemented business validations to:
  - Prevent duplicate notification configurations for the same subscription.
  - Ensure the referenced subscription exists before creating a notification.
- Automatically calculate the initial `nextNotificationDate` based on the subscription ending date and the configured notification range.
- Added cache support for notification retrieval and cache eviction annotations for update/delete operations.
- Introduced repository abstractions to keep the notification module aligned with the application's architecture.
- Added comprehensive controller and repository unit tests covering:
  - Success scenarios.
  - Validation failures.
  - Resource not found cases.
  - Conflict scenarios.
  - Invalid payload and path variable handling.

---

# Minimal Changes

- Added notification-specific cache constants and eviction annotation.
- Introduced DTO factory input object for entity creation.
- Added repository helper methods for subscription existence and lookup.
- Added validation constraints limiting configurable notification days.
- Standardized response mapping for notification resources.
- Added notification test datasets for validation scenarios.
- Improved URI generation for newly created notification resources.

---

# Notes

- This implementation provides the persistence and API layer only; automatic notification delivery is intentionally left for future iterations.
- Future work should include a scheduled task (Scheduler/Quartz/Spring Scheduling) responsible for processing pending notifications based on `nextNotificationDate`.
- The notification infrastructure can later be extended to support multiple delivery channels such as email, SMS, or push notifications without requiring significant domain changes.
- Additional endpoints for listing, filtering, and managing notification configurations may be implemented as the notification module evolves.
```