### PR TITLE
Oauth2 Authentication

### DIFF
--- a/src/main/java/com/jame/dev/gymApp/features/auth/application/model/AuthProvider.java
+++ b/src/main/java/com/jame/dev/gymApp/features/auth/application/model/AuthProvider.java
@@ -1,5 +1,5 @@
 package com.jame.dev.gymApp.features.auth.application.model;
 
 public enum AuthProvider {
-   GOOGLE, LOCAL
+   GOOGLE, FACEBOOK, LOCAL
 }

--- a/src/main/java/com/jame/dev/gymApp/features/auth/domain/exception/AuthenticationAttemptFailureException.java
+++ b/src/main/java/com/jame/dev/gymApp/features/auth/domain/exception/AuthenticationAttemptFailureException.java
@@ -4,4 +4,8 @@ public class AuthenticationAttemptFailureException extends RuntimeException {
    public AuthenticationAttemptFailureException(String message) {
       super(message);
    }
+
+   public AuthenticationAttemptFailureException(String message, Throwable e) {
+      super(message, e);
+   }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/listeners/VerificationOauth2ListenerSaver.java
+++ b/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/listeners/VerificationOauth2ListenerSaver.java
@@ -1,16 +1,15 @@
 package com.jame.dev.gymApp.features.auth.infrastructure.listeners;
 
-import com.jame.dev.gymApp.infrastructure.security.hash.HashExecutor;
-import com.jame.dev.gymApp.infrastructure.security.token.TokenGeneratorService;
 import com.jame.dev.gymApp.features.auth.application.support.factory.VerificationFactory;
 import com.jame.dev.gymApp.features.auth.domain.event.VerifyOauthUserEvent;
-import com.jame.dev.gymApp.features.auth.domain.exception.VerificationAttemptFailedException;
 import com.jame.dev.gymApp.features.auth.domain.model.AuthenticatedUser;
 import com.jame.dev.gymApp.features.auth.domain.model.VerificationEntity;
 import com.jame.dev.gymApp.features.auth.domain.repository.VerificationRepository;
 import com.jame.dev.gymApp.features.user.domain.exception.UserEntityNotFoundException;
 import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
 import com.jame.dev.gymApp.features.user.domain.repository.UserQueryRepository;
+import com.jame.dev.gymApp.infrastructure.security.hash.HashExecutor;
+import com.jame.dev.gymApp.infrastructure.security.token.TokenGeneratorService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -34,7 +33,7 @@ public class VerificationOauth2ListenerSaver {
    public void saveAndVerifyOauthUser(final VerifyOauthUserEvent event) {
       final AuthenticatedUser user = event.user();
       if (verificationRepository.existsByUser_EmailAndVerifiedTrue(user.email()))
-         throw new VerificationAttemptFailedException("User already verified.");
+         return;
 
       final UserEntity userEntity = userQueryRepository.findByEmail(user.email())
          .orElseThrow(() -> new UserEntityNotFoundException("User not found." + user.email()));

--- a/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/oauth2/CustomOAuth2AuthenticationHandler.java
+++ b/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/oauth2/CustomOAuth2AuthenticationHandler.java
@@ -1,8 +1,8 @@
 package com.jame.dev.gymApp.features.auth.infrastructure.oauth2;
 
+import com.jame.dev.gymApp.features.auth.application.contract.JwtService;
 import com.jame.dev.gymApp.features.auth.application.support.helper.CookieHelper;
 import com.jame.dev.gymApp.features.auth.domain.exception.AuthenticationNullException;
-import com.jame.dev.gymApp.features.auth.application.contract.JwtService;
 import com.jame.dev.gymApp.features.auth.domain.model.CustomOAuth2User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,9 +34,8 @@ public class CustomOAuth2AuthenticationHandler implements AuthenticationSuccessH
    @Override
    public void onAuthenticationSuccess(final @NonNull HttpServletRequest request,
                                        final @NonNull HttpServletResponse response,
-                                       final Authentication authentication)
-      throws IOException {
-      log.info("[Oauth2 - AuthHandler]: HIT authentication handler.");
+                                       final Authentication authentication) {
+
       if (Objects.isNull(authentication.getPrincipal())) {
          throw new AuthenticationNullException("No user authenticated.");
       }
@@ -59,10 +58,15 @@ public class CustomOAuth2AuthenticationHandler implements AuthenticationSuccessH
       final ResponseCookie accessCookie = cookieHelper.createAccessTokenCookie(access);
       final ResponseCookie refreshCookie = cookieHelper.createRefreshTokenCookie(refreshToken);
 
-      response.setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+      response.setStatus(HttpStatus.PERMANENT_REDIRECT.value());
       response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
       response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
       request.getSession(false);
-      response.sendRedirect(REDIRECT_URL);
+
+      try {
+         response.sendRedirect(REDIRECT_URL);
+      } catch (IOException e) {
+         throw new RuntimeException("Cannot send redirect.", e);
+      }
    }
 }

--- a/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/oauth2/CustomOAuth2UserService.java
@@ -24,7 +24,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
    @VerifyOauthUser
    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
       final OAuth2User oAuth2User = super.loadUser(userRequest);
-      final AuthenticatedUser authenticatedUser = oauth2UserServiceHelper.createOrSaveUser(oAuth2User);
+      final String provider = userRequest.getClientRegistration().getRegistrationId();
+      final AuthenticatedUser authenticatedUser = oauth2UserServiceHelper.handleUser(oAuth2User, provider);
       final Collection<GrantedAuthority> authorities = oauth2UserServiceHelper.getAuthoritiesFrom(authenticatedUser);
       return new CustomOAuth2User(authenticatedUser, oAuth2User.getAttributes(), authorities);
    }

--- a/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/oauth2/CustomOauth2UserServiceHelper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/auth/infrastructure/oauth2/CustomOauth2UserServiceHelper.java
@@ -3,13 +3,13 @@ package com.jame.dev.gymApp.features.auth.infrastructure.oauth2;
 import com.jame.dev.gymApp.features.auth.application.model.AuthProvider;
 import com.jame.dev.gymApp.features.auth.domain.model.AuthenticatedUser;
 import com.jame.dev.gymApp.features.user.api.request.UserRequest;
-import com.jame.dev.gymApp.features.user.api.response.UserResponse;
 import com.jame.dev.gymApp.features.user.application.contract.UserFactory;
 import com.jame.dev.gymApp.features.user.application.support.mapper.RoleMapper;
 import com.jame.dev.gymApp.features.user.domain.exception.CantSaveUserException;
 import com.jame.dev.gymApp.features.user.domain.model.Role;
 import com.jame.dev.gymApp.features.user.domain.model.UserEntity;
-import com.jame.dev.gymApp.features.user.infrastructure.persistence.UserRepository;
+import com.jame.dev.gymApp.features.user.domain.repository.UserMutationRepository;
+import com.jame.dev.gymApp.features.user.domain.repository.UserQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -19,47 +19,61 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collection;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 @Component
 @RequiredArgsConstructor
 public class CustomOauth2UserServiceHelper {
-   private final UserRepository userRepository;
+   private final UserQueryRepository userQueryRepository;
+   private final UserMutationRepository mutationRepository;
    private final UserFactory userFactory;
    private final RoleMapper roleMapper;
 
+   private static final Function<String, AuthProvider> getAuthProvider =
+      valueOf -> Enum.valueOf(AuthProvider.class, valueOf.toUpperCase());
+
+   private static final BiFunction<OAuth2User, String, UserRequest> createUserRequest =
+      (user, provider) -> UserRequest.builder()
+         .name(user.getAttribute("name"))
+         .email(user.getAttribute("email"))
+         .password(UUID.randomUUID().toString())
+         .authProvider(getAuthProvider.apply(provider))
+         .roles(Set.of(Role.USER))
+         .build();
+
+   private static final Function<UserEntity, AuthenticatedUser> createAuthenticatedUser =
+      user -> AuthenticatedUser.builder()
+         .id(user.getId())
+         .name(user.getName())
+         .email(user.getEmail())
+         .roles(Set.of(Role.USER))
+         .build();
+
    @Transactional
-   public AuthenticatedUser createOrSaveUser(final OAuth2User oAuth2User) {
+   public AuthenticatedUser handleUser(final OAuth2User oAuth2User, final String provider) {
       final String email = oAuth2User.getAttribute("email");
+
       if (email == null) {
          throw new CantSaveUserException("Some fields are not valid to proceed.");
       }
-      final UserResponse user = userRepository.findByEmail(email)
-         .map(userFactory::createFromEntity)
-         .orElseGet(() -> saveUser(oAuth2User));
 
-      return AuthenticatedUser.builder()
-         .id(user.id())
-         .name(user.name())
-         .email(user.email())
-         .roles(Set.of(Role.USER))
-         .build();
+      return userQueryRepository.findByEmail(email)
+         .map(u -> {
+            if (!u.isActive()) {
+               u.setActive(true);
+            }
+            return createAuthenticatedUser.apply(u);
+         })
+         .orElseGet(() -> {
+            final UserRequest userRequest = createUserRequest.apply(oAuth2User, provider);
+            final UserEntity user = mutationRepository.save(userFactory.createFromInput(userRequest));
+            return createAuthenticatedUser.apply(user);
+         });
    }
 
    public Collection<GrantedAuthority> getAuthoritiesFrom(final AuthenticatedUser authenticatedUser) {
-      final Set<Role> roles = authenticatedUser.roles();
-      return roleMapper.rolesToGrantedAuthorities(roles);
-   }
-
-   public UserResponse saveUser(final OAuth2User oAuth2User) {
-      final UserRequest userRequest = UserRequest.builder()
-         .name(oAuth2User.getAttribute("name"))
-         .email(oAuth2User.getAttribute("email"))
-         .password(UUID.randomUUID().toString())
-         .authProvider(AuthProvider.GOOGLE)
-         .roles(Set.of(Role.USER))
-         .build();
-      final UserEntity user = userRepository.save(userFactory.createFromInput(userRequest));
-      return userFactory.createFromEntity(user);
+      return roleMapper.rolesToGrantedAuthorities(authenticatedUser.roles());
    }
 
 }

--- a/src/main/java/com/jame/dev/gymApp/features/notification/application/support/mapper/SubscriberNotificationMapper.java
+++ b/src/main/java/com/jame/dev/gymApp/features/notification/application/support/mapper/SubscriberNotificationMapper.java
@@ -18,7 +18,6 @@ public interface SubscriberNotificationMapper extends BaseMapper<SubscriberNotif
    @Mapping(target = "uuid", source = "entity.id")
    @Mapping(target = "rangeDaysNotification", source = "entity.rangeNotificationDays")
    @Mapping(target = "nextNotificationDate", source = "entity.nextNotificationDate", dateFormat = "EEEE, MMMM dd, yyyy")
-   @Mapping(target = "lastNotificationDate", source = "entity.lastNotificationDate", dateFormat = "EEEE, MMMM dd, yyyy")
    SubscriberNotificationResponse toDto(SubscriberNotificationEntity entity);
 
    default SubscriberNotificationEntity toEntity(SubscriberNotificationFactoryDtoInput input) {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -3,7 +3,7 @@ spring.config.import=optional:file:.env.dev[.properties]
 
 #app
 app.cors.allowed-origins=http://localhost:5173
-app.auth.redirect-url=http://localhost:5173/home
+app.auth.redirect-url=http://localhost:5173/checksum
 app.auth.redirect.url.password-reset=http://localhost:5173/password-reset
 
 # JPA DEV
@@ -45,6 +45,10 @@ app.mapping.user=${APP_USER_MAPPING}
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 spring.security.oauth2.client.registration.google.scope=email,profile
+
+spring.security.oauth2.client.registration.facebook.client-id=${FACEBOOK_CLIENT_ID}
+spring.security.oauth2.client.registration.facebook.client-secret=${FACEBOOK_CLIENT_SECRET}
+spring.security.oauth2.client.registration.facebook.scope=email,public_profile
 
 # STRIPE DEV
 stripe.secret-key=${STRIPE_SECRET_KEY}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -31,6 +31,10 @@ spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
 spring.security.oauth2.client.registration.google.scope=email,profile
 
+spring.security.oauth2.client.registration.facebook.client-id=${FACEBOOK_CLIENT_ID}
+spring.security.oauth2.client.registration.facebook.client-secret=${FACEBOOK_CLIENT_SECRET}
+spring.security.oauth2.client.registration.facebook.scope=email,public_profile
+
 # STRIPE PROD
 stripe.secret-key=${STRIPE_SECRET_KEY}
 stripe.webhook-secret=${STRIPE_WEBHOOK_SECRET}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,9 @@ spring.profiles.active=dev
 spring.application.name=gym-app
 spring.main.banner-mode=off
 
+logging.level.root=INFO
+logging.level.com.jame.dev.gymApp=DEBUG
+
 spring.threads.virtual.enabled=true
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
@@ -35,6 +38,7 @@ spring.mail.properties.mail.smtp.starttls.required=true
 
 # OAUTH2
 spring.security.oauth2.client.registration.google.redirect-uri=${REDIRECT_URL}
+spring.security.oauth2.client.registration.facebook.redirect-uri=${REDIRECT_URL}
 
 app.lock.preventive.lifetime-minutes=2
 app.lock.preventive.key=lock:process


### PR DESCRIPTION
# Description
This PR refactors the OAuth2 authentication flow to improve maintainability, readability, and extensibility while introducing support for Facebook as an authentication provider. The changes simplify the user handling logic, reduce boilerplate code in the OAuth2 helper, and configure the application to authenticate users through both Google and Facebook providers.

# Main Changes
- Refactored `CustomOauth2UserServiceHelper` to centralize OAuth2 user handling into a single `handleUser(...)` method.
- Replaced duplicated user creation logic with reusable `Function` and `BiFunction` implementations for:
  - Authentication provider resolution.
  - `UserRequest` creation.
  - `AuthenticatedUser` creation.
- Added **Facebook** as a supported `AuthProvider`.
- Added Facebook OAuth2 client configuration for both **development** and **production** profiles.
- Updated `CustomOAuth2UserService` to dynamically determine the OAuth2 provider from the current client registration instead of assuming Google.
- Split user persistence responsibilities by replacing the generic repository with dedicated `UserQueryRepository` and `UserMutationRepository`.
- Improved authentication flow by automatically reactivating inactive users when they authenticate through OAuth2.
- Updated the OAuth2 authentication success handler:
  - Changed redirect status to **308 Permanent Redirect**.
  - Wrapped redirect execution to provide explicit failure handling.
- Added a new constructor to `AuthenticationAttemptFailureException` supporting exception chaining.
- Prevented unnecessary verification attempts by returning early when an OAuth2 user is already verified.
- Configured Facebook redirect URI in the shared application configuration.

# Minimal Changes
- Removed unnecessary intermediate variables and simplified authority mapping.
- Reorganized imports across several classes.
- Removed the mapping of `lastNotificationDate` from `SubscriberNotificationMapper`.
- Updated the development OAuth2 redirect URL from `/home` to `/checksum`.
- Added default logging configuration for root and application packages.

# Notes
- The current OAuth2 implementation is now provider-agnostic, making it significantly easier to integrate additional providers (e.g. Apple, GitHub, Microsoft) with minimal changes.
- The new helper structure provides a cleaner foundation for future improvements such as provider-specific attribute mapping or a strategy-based OAuth2 implementation.